### PR TITLE
Add optional linux PACKET_RX_RING support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -489,6 +489,23 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
 		AC_MSG_RESULT([no])
 	])
 
+AC_MSG_CHECKING([for struct tpacket_req3])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+	[[
+		#include <linux/if_packet.h>
+	]],
+	[[
+		struct tpacket_req3 req3;
+	]])],
+	[
+		AC_MSG_RESULT([yes])
+		AC_DEFINE_UNQUOTED([HAVE_STRUCT_TPACKET_REQ3], 1,
+		[Define to 1 if you have the `tpacket_req3' struct.])
+	],
+	[
+		AC_MSG_RESULT([no])
+	])
+
 # These libraries have to be explicitly linked in OpenSolaris
 AC_SEARCH_LIBS(getaddrinfo, socket, [], [], -lnsl)
 AC_SEARCH_LIBS(inet_ntop, nsl, [], [], -lsocket)

--- a/configure.ac
+++ b/configure.ac
@@ -275,6 +275,7 @@ AC_CHECK_HEADERS(sys/socketvar.h)
 AC_CHECK_HEADERS(sys/time.h)
 AC_CHECK_HEADERS(unistd.h)
 AC_CHECK_HEADERS(ifaddrs.h)
+AC_CHECK_HEADERS(linux/if_packet.h)
 
 # sys/sysctl.h requires other headers on at least OpenBSD
 AC_CHECK_HEADERS([sys/sysctl.h], [], [],

--- a/internal.h
+++ b/internal.h
@@ -178,7 +178,12 @@ typedef unsigned short sa_family_t;
 #endif
 
 #if defined(__linux__)
+#ifdef HAVE_LINUX_IF_PACKET_H
+#include <linux/if_packet.h>
+#else
 #include <netpacket/packet.h>
+#endif
+
 #include <net/ethernet.h>
 #include <net/if_arp.h>
 #include <linux/types.h>
@@ -187,6 +192,7 @@ typedef unsigned short sa_family_t;
 #include <linux/sockios.h>
 #include <linux/errqueue.h>
 #include <limits.h>
+#include <sys/mman.h>
 
 #ifdef HAVE_LINUX_NETLINK_H
 #include <linux/netlink.h>

--- a/scamper/scamper.1
+++ b/scamper/scamper.1
@@ -290,6 +290,12 @@ on systems where
 .Xr epoll 7
 is available.
 .It
+.Sy ring:
+tell scsamper to use PACKET_RX_RING (see
+.Xr packet 7) to receive
+datalink responses. This significantly improves scamper
+performance and accuracy on systems with other non-scamper traffic.
+.It
 .Sy cmdfile:
 the input file consists of complete commands.
 .It

--- a/scamper/scamper.c
+++ b/scamper/scamper.c
@@ -133,6 +133,7 @@
 #define FLAG_ICMP_RECVERR    0x00000400
 #endif
 #define FLAG_POLL            0x00000800
+#define FLAG_RING            0x00001000
 
 /*
  * parameters configurable by the command line:
@@ -364,6 +365,9 @@ static void usage(uint32_t opt_mask)
 #endif
 #ifndef WITHOUT_DEBUGFILE
       usage_line("debugfileappend: append to debugfile, rather than truncate");
+#endif
+#ifdef HAVE_STRUCT_TPACKET_REQ3
+      usage_line("ring: use TPACKET_V3");
 #endif
     }
 
@@ -727,6 +731,10 @@ static int check_options(int argc, char *argv[])
 	    remote_client_privfile = optarg+16;
 	  else if(strncasecmp(optarg, "client-certfile=", 16) == 0)
 	    remote_client_certfile = optarg+16;
+#endif
+#ifdef HAVE_STRUCT_TPACKET_REQ3
+	  else if(strcasecmp(optarg, "ring") == 0)
+	    flags |= FLAG_RING;
 #endif
 	  else
 	    {
@@ -1227,6 +1235,14 @@ int scamper_option_notls(void)
 int scamper_option_daemon(void)
 {
   if(options & OPT_DAEMON) return 1;
+  return 0;
+}
+
+int scamper_option_ring(void)
+{
+#ifdef HAVE_STRUCT_TPACKET_REQ3
+  if(flags & FLAG_RING) return 1;
+#endif
   return 0;
 }
 

--- a/scamper/scamper.h
+++ b/scamper/scamper.h
@@ -61,6 +61,7 @@ int scamper_option_rawtcp(void);
 int scamper_option_icmp_rxerr(void);
 int scamper_option_debugfileappend(void);
 int scamper_option_daemon(void);
+int scamper_option_ring(void);
 
 void scamper_exitwhendone(int on);
 

--- a/scamper/scamper_dl.c
+++ b/scamper/scamper_dl.c
@@ -1294,16 +1294,16 @@ static int dl_linux_ring_init(scamper_dl_t *dl) {
   ring->blocks_cnt = block_cnt;
   ring->cur_block = 0;
 
-  fprintf(stderr,
-          "%s: initializing PACKET_RX_RING. "
-          "block_size=%d, frame_size=%d, block_cnt=%d, "
-          "frame_cnt=%d, alloc_size=%d, "
-          "tp_block_size=%d, tp_block_nr=%d, "
-          "tp_frame_size=%d, tp_frame_nr=%d\n",
-          __func__, block_size, frame_size, block_cnt, frame_cnt,
-          block_size * block_cnt,
-          ring->req.tp_block_size, ring->req.tp_block_nr,
-          ring->req.tp_frame_size, ring->req.tp_frame_nr);
+  scamper_debug(__func__,
+                "%s: initializing PACKET_RX_RING. "
+                "block_size=%d, frame_size=%d, block_cnt=%d, "
+                "frame_cnt=%d, alloc_size=%d, "
+                "tp_block_size=%d, tp_block_nr=%d, "
+                "tp_frame_size=%d, tp_frame_nr=%d\n",
+                __func__, block_size, frame_size, block_cnt, frame_cnt,
+                block_size * block_cnt,
+                ring->req.tp_block_size, ring->req.tp_block_nr,
+                ring->req.tp_frame_size, ring->req.tp_frame_nr);
 
   if (setsockopt(fd, SOL_PACKET, PACKET_VERSION,
                  &pkt_version, sizeof(pkt_version)) == -1)

--- a/scamper/scamper_fds.c
+++ b/scamper/scamper_fds.c
@@ -409,7 +409,7 @@ static void fd_refcnt_0(scamper_fd_t *fdn)
    * along and wants to use it.
    */
   gettimeofday_wrap(&fdn->tv);
-  fdn->tv.tv_sec += 10;
+  fdn->tv.tv_sec += 60;
 
   return;
 }


### PR DESCRIPTION
Set `-O ring` to enable. Should improve scamper accuracy for TCP measurements -- especially on hosts with a lot of non-scamper traffic.

Also increases FD garbage collection timeout from 10s to 60s to avoid constantly re-creating sockets.