### PR TITLE
Add ring-nolocked option to disable MAP_LOCKED

### DIFF
--- a/scamper/scamper.1
+++ b/scamper/scamper.1
@@ -304,6 +304,12 @@ Defaults to 64.
 set the number of bytes in each block of the PACKET_RX_RING.
 Defaults to 65k.
 .It
+.Sy ring-nolocked:
+do not use MAP_LOCKED when allocating ring. This will allow the ring
+to be used on systems with low locked memory limits (ulimit -l), but
+at the risk of the ring being swapped. This option should only be
+used if swap is disabled.
+.It
 .Sy cmdfile:
 the input file consists of complete commands.
 .It

--- a/scamper/scamper.c
+++ b/scamper/scamper.c
@@ -227,6 +227,7 @@ static char *remote_client_certfile = NULL;
 /* runtime config for linux AF_PACKET ring */
 static unsigned int ring_block_size = 1 << 16; /* 65 KiB */
 static unsigned int ring_blocks = 64;
+int ring_nolocked = 0; /* don't use MAP_LOCKED if set */
 
 /* Source port to use in our probes */
 static uint16_t default_sport = 0;
@@ -743,6 +744,8 @@ static int check_options(int argc, char *argv[])
       ring_blocks = strtoul(optarg + 12, NULL, 10);
     else if(strncasecmp(optarg, "ring-block-size=", 16) == 0)
       ring_block_size = strtoul(optarg + 16, NULL, 10);
+    else if(strcasecmp(optarg, "ring-nolocked") == 0)
+      ring_nolocked = 1;
 #endif
 	  else
 	    {
@@ -1254,14 +1257,19 @@ int scamper_option_ring(void)
   return 0;
 }
 
-unsigned int scamper_option_ring_blocks()
+unsigned int scamper_option_ring_blocks(void)
 {
   return ring_blocks;
 }
 
-unsigned int scamper_option_ring_block_size()
+unsigned int scamper_option_ring_block_size(void)
 {
   return ring_block_size;
+}
+
+int scamper_option_ring_nolocked(void)
+{
+  return ring_nolocked;
 }
 
 #ifdef HAVE_SETEUID

--- a/scamper/scamper.h
+++ b/scamper/scamper.h
@@ -64,6 +64,7 @@ int scamper_option_daemon(void);
 int scamper_option_ring(void);
 unsigned int scamper_option_ring_blocks(void);
 unsigned int scamper_option_ring_block_size(void);
+int scamper_option_ring_nolocked(void);
 
 void scamper_exitwhendone(int on);
 

--- a/scamper/scamper_dl.c
+++ b/scamper/scamper_dl.c
@@ -1270,7 +1270,7 @@ static int dl_linux_ring_read(scamper_dl_t *node)
 static int dl_linux_ring_init(scamper_dl_t *dl) {
   struct ring *ring = &dl->ring;
   int fd = scamper_fd_fd_get(dl->fdn);
-  int i;
+  int i, flags;
 
   int pkt_version = TPACKET_V3;
   unsigned int block_size = scamper_option_ring_block_size();
@@ -1315,15 +1315,20 @@ static int dl_linux_ring_init(scamper_dl_t *dl) {
     return -1;
   }
 
-  // Allocate our ring. Even though the circular buffer is compound of several
-  // physically discontiguous blocks of memory, they are contiguous to the user
-  // space, hence just one call to mmap is needed.
-  if ((ring->map =
-           mmap(NULL, ring->map_size,
-                PROT_READ | PROT_WRITE, MAP_SHARED | MAP_LOCKED,
-                fd, 0)) == MAP_FAILED) {
-    printerror(__func__, "ring mmap failed");
-    return -1;
+  /* Allocate our ring. Even though the circular buffer is compound of several
+   * physically discontiguous blocks of memory, they are contiguous to the user
+   * space, hence just one call to mmap is needed.
+   */
+  flags = MAP_SHARED | MAP_POPULATE;
+  if (scamper_option_ring_nolocked() == 0)
+  {
+      flags |= MAP_LOCKED;
+  }
+  if ((ring->map = mmap(NULL, ring->map_size, PROT_READ | PROT_WRITE,
+                        flags, fd, 0)) == MAP_FAILED)
+  {
+      printerror(__func__, "ring mmap failed");
+      return -1;
   }
 
   // Allocate the iovecs that we'll use to find the blocks in the ring


### PR DESCRIPTION
Allow the ring to be allocated without use of MAP_LOCKED. This will
allow the ring to be used on systems with low locked memory limits
(ulimit -l), but at the risk of the ring being swapped. This option
should only be used if swap is disabled.