### PR TITLE
add json output for udpprobe, and support multiple probes

### DIFF
--- a/scamper/Makefile.am
+++ b/scamper/Makefile.am
@@ -70,6 +70,7 @@ libscamperfile_la_SOURCES = \
 	http/scamper_http_lib.c \
 	udpprobe/scamper_udpprobe.c \
 	udpprobe/scamper_udpprobe_warts.c \
+	udpprobe/scamper_udpprobe_json.c \
 	udpprobe/scamper_udpprobe_lib.c
 
 scamper_SOURCES = \
@@ -210,6 +211,7 @@ if ENABLE_SCAMPER_UDPPROBE
 scamper_SOURCES += \
 	udpprobe/scamper_udpprobe.c \
 	udpprobe/scamper_udpprobe_warts.c \
+	udpprobe/scamper_udpprobe_json.c \
 	udpprobe/scamper_udpprobe_cmd.c \
 	udpprobe/scamper_udpprobe_do.c
 endif

--- a/scamper/ping/scamper_ping_do.c
+++ b/scamper/ping/scamper_ping_do.c
@@ -1649,10 +1649,12 @@ scamper_task_t *scamper_do_ping_alloctask(void *data, scamper_list_t *list,
       if(SCAMPER_ADDR_TYPE_IS_IPV4(ping->dst))
 	state->fds[0] = scamper_fd_udp4dg_dst(ping->src->addr,
 					      ping->probe_sport,
+					      NULL, 0,
 					      ping->dst->addr,
 					      ping->probe_dport);
       else
 	state->fds[0] = scamper_fd_udp6_dst(ping->src->addr, ping->probe_sport,
+					    NULL, 0,
 					    ping->dst->addr, ping->probe_dport);
       if(state->fds[0] == NULL)
 	{

--- a/scamper/scamper_fds.c
+++ b/scamper/scamper_fds.c
@@ -1256,12 +1256,13 @@ static scamper_fd_t *fd_tcp(int type, void *src, uint16_t sport,
 }
 
 static scamper_fd_t *fd_udp(int type, void *src, uint16_t sport,
+			    uint16_t *sportx, size_t sportxc,
 			    void *dst, uint16_t dport)
 {
   scamper_addr_t sa;
   scamper_fd_t *fdn = NULL, *exist, findme;
   dlist_node_t *dn;
-  size_t len = 0;
+  size_t s, len = 0;
   int rc;
 
 #ifndef _WIN32 /* SOCKET vs int on windows */
@@ -1305,6 +1306,16 @@ static scamper_fd_t *fd_udp(int type, void *src, uint16_t sport,
 	  exist = dlist_node_item(dn);
 	  if(exist->type != type)
 	    continue;
+
+	  /* has the caller asked to not provide specific sports? */
+	  if(sportx != NULL)
+	    {
+	      for(s=0; s<sportxc; s++)
+		if(sportx[s] == exist->fd_sport)
+		  break;
+	      if(s != sportxc)
+		continue;
+	    }
 	  rc = scamper_task_sig_sport_used(&sa, IPPROTO_UDP,
 					   exist->fd_sport, dport);
 	  if(rc == -1)
@@ -1640,7 +1651,8 @@ scamper_fd_t *scamper_fd_tcp6_dst(void *src, uint16_t sport,
 scamper_fd_t *scamper_fd_udp4dg(void *src, uint16_t sport)
 {
   scamper_fd_t *fdn;
-  if((fdn = fd_udp(SCAMPER_FD_TYPE_UDP4DG, src, sport, NULL, 0)) != NULL)
+  fdn = fd_udp(SCAMPER_FD_TYPE_UDP4DG, src, sport, NULL, 0, NULL, 0);
+  if(fdn != NULL)
     {
       fdn->read.cb = scamper_udp4_read_cb;
       scamper_fd_read_unpause(fdn);
@@ -1649,10 +1661,12 @@ scamper_fd_t *scamper_fd_udp4dg(void *src, uint16_t sport)
 }
 
 scamper_fd_t *scamper_fd_udp4dg_dst(void *src, uint16_t sport,
+				    uint16_t *sportx, size_t sportxc,
 				    void *dst, uint16_t dport)
 {
   scamper_fd_t *fdn;
-  if((fdn = fd_udp(SCAMPER_FD_TYPE_UDP4DG, src, sport, dst, dport)) != NULL)
+  fdn = fd_udp(SCAMPER_FD_TYPE_UDP4DG, src, sport, sportx, sportxc, dst, dport);
+  if(fdn != NULL)
     {
       fdn->read.cb = scamper_udp4_read_cb;
       scamper_fd_read_unpause(fdn);
@@ -1662,13 +1676,14 @@ scamper_fd_t *scamper_fd_udp4dg_dst(void *src, uint16_t sport,
 
 scamper_fd_t *scamper_fd_udp4raw(void *src)
 {
-  return fd_udp(SCAMPER_FD_TYPE_UDP4RAW, src, 0, NULL, 0);
+  return fd_udp(SCAMPER_FD_TYPE_UDP4RAW, src, 0, NULL, 0, NULL, 0);
 }
 
 scamper_fd_t *scamper_fd_udp6(void *src, uint16_t sport)
 {
   scamper_fd_t *fdn;
-  if((fdn = fd_udp(SCAMPER_FD_TYPE_UDP6, src, sport, NULL, 0)) != NULL)
+  fdn = fd_udp(SCAMPER_FD_TYPE_UDP6, src, sport, NULL, 0, NULL, 0);
+  if(fdn != NULL)
     {
       fdn->read.cb = scamper_udp6_read_cb;
       scamper_fd_read_unpause(fdn);
@@ -1677,15 +1692,24 @@ scamper_fd_t *scamper_fd_udp6(void *src, uint16_t sport)
 }
 
 scamper_fd_t *scamper_fd_udp6_dst(void *src, uint16_t sport,
+				  uint16_t *sportx, size_t sportxc,
 				  void *dst, uint16_t dport)
 {
-  return fd_udp(SCAMPER_FD_TYPE_UDP6, src, sport, dst, dport);
+  scamper_fd_t *fdn;
+  fdn = fd_udp(SCAMPER_FD_TYPE_UDP6, src, sport, sportx, sportxc, dst, dport);
+  if(fdn != NULL)
+    {
+      fdn->read.cb = scamper_udp6_read_cb;
+      scamper_fd_read_unpause(fdn);
+    }
+  return fdn;
 }
 
 scamper_fd_t *scamper_fd_udp6err(void *src, uint16_t sport)
 {
   scamper_fd_t *fdn;
-  if((fdn = fd_udp(SCAMPER_FD_TYPE_UDP6ERR, src, sport, NULL, 0)) != NULL)
+  fdn = fd_udp(SCAMPER_FD_TYPE_UDP6ERR, src, sport, NULL, 0, NULL, 0);
+  if(fdn != NULL)
     {
       fdn->read.param = fdn;
       fdn->read.cb = scamper_udp6_read_err_cb;
@@ -1695,10 +1719,12 @@ scamper_fd_t *scamper_fd_udp6err(void *src, uint16_t sport)
 }
 
 scamper_fd_t *scamper_fd_udp6err_dst(void *src, uint16_t sport,
+				     uint16_t *sportx, size_t sportxc,
 				     void *dst, uint16_t dport)
 {
   scamper_fd_t *fdn;
-  if((fdn = fd_udp(SCAMPER_FD_TYPE_UDP6ERR, src, sport, dst, dport)) != NULL)
+  if((fdn = fd_udp(SCAMPER_FD_TYPE_UDP6ERR, src, sport, sportx, sportxc,
+		   dst, dport)) != NULL)
     {
       fdn->read.param = fdn;
       fdn->read.cb = scamper_udp6_read_err_cb;

--- a/scamper/scamper_fds.h
+++ b/scamper/scamper_fds.h
@@ -49,10 +49,13 @@ scamper_fd_t *scamper_fd_dl(int ifindex);
 scamper_fd_t *scamper_fd_ip4(void);
 
 scamper_fd_t *scamper_fd_udp4dg_dst(void *src, uint16_t sport,
+				    uint16_t *sportx, size_t sportxc,
 				    void *dst, uint16_t dport);
 scamper_fd_t *scamper_fd_udp6_dst(void *src, uint16_t sport,
+				  uint16_t *sportx, size_t sportxc,
 				  void *dst, uint16_t dport);
 scamper_fd_t *scamper_fd_udp6err_dst(void *src, uint16_t sport,
+				     uint16_t *sportx, size_t sportxc,
 				     void *dst, uint16_t dport);
 scamper_fd_t *scamper_fd_tcp4_dst(void *src, uint16_t sport,
 				  uint16_t *sportx, size_t sportxc,

--- a/scamper/scamper_file.c
+++ b/scamper/scamper_file.c
@@ -90,6 +90,7 @@
 #if !defined(BUILDING_SCAMPER) || !defined(DISABLE_SCAMPER_UDPPROBE)
 #include "udpprobe/scamper_udpprobe.h"
 #include "udpprobe/scamper_udpprobe_warts.h"
+#include "udpprobe/scamper_udpprobe_json.h"
 #endif
 
 #include "utils.h"
@@ -284,7 +285,7 @@ static write_handlers_t json_write_handlers =
   NULL,                                   /* http */
 #endif
 #if !defined(BUILDING_SCAMPER) || !defined(DISABLE_SCAMPER_UDPPROBE)
-  NULL,                                   /* udpprobe */
+ scamper_file_json_udpprobe_write,        /* udpprobe */
 #endif
 };
 

--- a/scamper/trace/scamper_trace_do.c
+++ b/scamper/trace/scamper_trace_do.c
@@ -4306,6 +4306,7 @@ scamper_task_t *scamper_do_trace_alloctask(void *data,
       else if(SCAMPER_TRACE_TYPE_IS_UDP(trace) &&
 	      SCAMPER_ADDR_TYPE_IS_IPV6(trace->dst))
 	state->probe = scamper_fd_udp6err_dst(trace->src->addr, trace->sport,
+					      NULL, 0,
 					      trace->dst->addr, trace->dport);
     }
   else
@@ -4331,10 +4332,12 @@ scamper_task_t *scamper_do_trace_alloctask(void *data,
 	  if(trace->dst->type == SCAMPER_ADDR_TYPE_IPV4)
 	    state->probe = scamper_fd_udp4dg_dst(trace->src->addr,
 						 trace->sport,
+						 NULL, 0,
 						 trace->dst->addr,
 						 trace->dport);
 	  else
 	    state->probe = scamper_fd_udp6_dst(trace->src->addr, trace->sport,
+					       NULL, 0,
 					       trace->dst->addr, trace->dport);
 	}
     }

--- a/scamper/udpprobe/scamper_udpprobe.h
+++ b/scamper/udpprobe/scamper_udpprobe.h
@@ -24,6 +24,7 @@
 #define __SCAMPER_UDPPROBE_H
 
 typedef struct scamper_udpprobe scamper_udpprobe_t;
+typedef struct scamper_udpprobe_probe scamper_udpprobe_probe_t;
 typedef struct scamper_udpprobe_reply scamper_udpprobe_reply_t;
 
 /* scamper_udpprobe_t functions */
@@ -37,17 +38,27 @@ uint16_t scamper_udpprobe_sport_get(const scamper_udpprobe_t *up);
 uint16_t scamper_udpprobe_dport_get(const scamper_udpprobe_t *up);
 const struct timeval *scamper_udpprobe_start_get(const scamper_udpprobe_t *up);
 const struct timeval *scamper_udpprobe_wait_timeout_get(const scamper_udpprobe_t *up);
+const struct timeval *scamper_udpprobe_wait_probe_get(const scamper_udpprobe_t *up);
 int scamper_udpprobe_flag_is_exitfirst(const scamper_udpprobe_t *up);
 const uint8_t *scamper_udpprobe_data_get(const scamper_udpprobe_t *up);
 uint16_t scamper_udpprobe_len_get(const scamper_udpprobe_t *up);
-scamper_udpprobe_reply_t *scamper_udpprobe_reply_get(const scamper_udpprobe_t *up, uint8_t i);
-uint8_t scamper_udpprobe_replyc_get(const scamper_udpprobe_t *up);
+uint8_t scamper_udpprobe_probe_count_get(const scamper_udpprobe_t *up);
+uint8_t scamper_udpprobe_probe_sent_get(const scamper_udpprobe_t *up);
+uint8_t scamper_udpprobe_stop_count_get(const scamper_udpprobe_t *up);
+scamper_udpprobe_probe_t *scamper_udpprobe_probe_get(const scamper_udpprobe_t *up, uint8_t i);
+
+/* scamper_udpprobe_probe_t functions */
+const struct timeval *scamper_udpprobe_probe_tx_get(const scamper_udpprobe_probe_t *probe);
+uint16_t scamper_udpprobe_probe_sport_get(const scamper_udpprobe_probe_t *probe);
+scamper_udpprobe_reply_t *scamper_udpprobe_probe_reply_get(const scamper_udpprobe_probe_t *probe, uint8_t i);
+uint8_t scamper_udpprobe_probe_replyc_get(const scamper_udpprobe_probe_t *probe);
+void scamper_udpprobe_probe_free(scamper_udpprobe_probe_t *pr);
 
 /* scamper_udpprobe_reply_t functions */
 void scamper_udpprobe_reply_free(scamper_udpprobe_reply_t *ur);
 scamper_udpprobe_reply_t *scamper_udpprobe_reply_use(scamper_udpprobe_reply_t *ur);
 const uint8_t *scamper_udpprobe_reply_data_get(const scamper_udpprobe_reply_t *ur);
 uint16_t scamper_udpprobe_reply_len_get(const scamper_udpprobe_reply_t *ur);
-const struct timeval *scamper_udpprobe_reply_tv_get(const scamper_udpprobe_reply_t *ur);
+const struct timeval *scamper_udpprobe_reply_rx_get(const scamper_udpprobe_reply_t *ur);
 
 #endif /* __SCAMPER_UDPPROBE_H */

--- a/scamper/udpprobe/scamper_udpprobe_do.c
+++ b/scamper/udpprobe/scamper_udpprobe_do.c
@@ -48,8 +48,10 @@ static scamper_task_funcs_t udpprobe_funcs;
 
 typedef struct udpprobe_state
 {
-  scamper_fd_t *fdn;
-  slist_t      *urs;
+  scamper_fd_t **fds;
+  slist_t       *probes;
+  slist_t      **replies;
+  int            probec;
 } udpprobe_state_t;
 
 static scamper_udpprobe_t *udpprobe_getdata(const scamper_task_t *task)
@@ -66,32 +68,69 @@ static void udpprobe_stop(scamper_task_t *task, uint8_t reason)
 {
   scamper_udpprobe_t *up = udpprobe_getdata(task);
   udpprobe_state_t *state = udpprobe_getstate(task);
-  scamper_udpprobe_reply_t *ur;
-  int i, c;
+  scamper_udpprobe_probe_t *probe;
+  scamper_udpprobe_reply_t *reply;
+  int i, j, pc, rc;
 
   up->stop = reason;
 
-  if(state != NULL && state->urs != NULL)
+  if(state != NULL && state->probes != NULL &&
+     (pc = slist_count(state->probes)) > 0)
     {
+      up->probes = malloc_zero(sizeof(scamper_udpprobe_probe_t *) * pc);
+      if(up->probes == NULL)
+	goto done;
+
       i = 0;
-      c = slist_count(state->urs);
-      up->replies = malloc_zero(sizeof(scamper_udpprobe_reply_t *) * c);
-      if(up->replies != NULL)
-	while((ur = slist_head_pop(state->urs)) != NULL)
-	  up->replies[i++] = ur;
-      up->replyc = i;
+      while((probe = slist_head_pop(state->probes)) != NULL)
+	up->probes[i++] = probe;
+      up->probe_sent = i;
+
+      for(i=0; i<pc; i++)
+	{
+	  probe = up->probes[i];
+	  rc = slist_count(state->replies[i]);
+	  if(rc == 0)
+	    continue;
+	  probe->replies = malloc_zero(sizeof(scamper_udpprobe_reply_t *) * rc);
+	  if(probe->replies != NULL)
+	    {
+	      j = 0;
+	      while((reply = slist_head_pop(state->replies[i])) != NULL)
+		probe->replies[j++] = reply;
+	      probe->replyc = j;
+	    }
+	}
     }
 
+ done:
   scamper_task_queue_done(task, 0);
   return;
 }
 
-static void udpprobe_state_free(udpprobe_state_t *state)
+static void udpprobe_state_free(scamper_udpprobe_t *up, udpprobe_state_t *state)
 {
-  if(state->urs != NULL)
-    slist_free_cb(state->urs, (slist_free_t)scamper_udpprobe_reply_free);
-  if(state->fdn != NULL)
-    scamper_fd_free(state->fdn);
+  uint8_t i;
+
+  if(state->replies != NULL)
+    {
+      for(i=0; i<up->probe_count; i++)
+	slist_free_cb(state->replies[i],
+		      (slist_free_t)scamper_udpprobe_reply_free);
+      free(state->replies);
+    }
+
+  if(state->probes != NULL)
+    slist_free_cb(state->probes, (slist_free_t)scamper_udpprobe_probe_free);
+
+  if(state->fds != NULL)
+    {
+      for(i=0; i<up->probe_count; i++)
+	if(state->fds[i] != NULL)
+	  scamper_fd_free(state->fds[i]);
+      free(state->fds);
+    }
+
   free(state);
   return;
 }
@@ -100,31 +139,29 @@ static void do_udpprobe_handle_udp(scamper_task_t *task, scamper_udp_resp_t *ur)
 {
   scamper_udpprobe_t *up = udpprobe_getdata(task);
   udpprobe_state_t *state = udpprobe_getstate(task);
-  scamper_udpprobe_reply_t *upr;
+  scamper_udpprobe_reply_t *reply;
+  int i;
 
   if(state == NULL)
     return;
 
-  /*
-   * ignore the response if it was received on a different socket than
-   * we probed with.  this is to avoid recording duplicate replies
-   */
-  if(ur->fd != scamper_fd_fd_get(state->fdn))
+  /* find the socket we sent the probe with */
+  for(i=0; i<state->probec; i++)
+    if(ur->fd == scamper_fd_fd_get(state->fds[i]))
+      break;
+  if(i == state->probec)
     return;
 
-  if(ur->sport != up->dport)
-    return;
-
-  if((upr = scamper_udpprobe_reply_alloc()) == NULL ||
-     (upr->data = memdup(ur->data, ur->datalen)) == NULL)
+  if((reply = scamper_udpprobe_reply_alloc()) == NULL ||
+     (reply->data = memdup(ur->data, ur->datalen)) == NULL)
     goto err;
   if(timeval_iszero(&ur->rx) == 0)
-    timeval_cpy(&upr->tv, &ur->rx);
+    timeval_cpy(&reply->rx, &ur->rx);
   else
-    gettimeofday_wrap(&upr->tv);
-  upr->len = ur->datalen;
+    gettimeofday_wrap(&reply->rx);
+  reply->len = ur->datalen;
 
-  if(slist_tail_push(state->urs, upr) == NULL)
+  if(slist_tail_push(state->replies[i], reply) == NULL)
     goto err;
 
   if(SCAMPER_UDPPROBE_FLAG_IS_EXITFIRST(up))
@@ -133,55 +170,53 @@ static void do_udpprobe_handle_udp(scamper_task_t *task, scamper_udp_resp_t *ur)
   return;
 
  err:
-  if(upr != NULL) scamper_udpprobe_reply_free(upr);
+  if(reply != NULL) scamper_udpprobe_reply_free(reply);
   return;
 }
 
-static udpprobe_state_t *udpprobe_state_alloc(scamper_task_t *task)
+static int udpprobe_state_alloc(scamper_task_t *task)
 {
   scamper_udpprobe_t *up = udpprobe_getdata(task);
-  udpprobe_state_t *state = NULL;
+  udpprobe_state_t *state = udpprobe_getstate(task);
+  uint8_t i;
 
-  if((state = malloc_zero(sizeof(udpprobe_state_t))) == NULL ||
-     (state->urs = slist_alloc()) == NULL)
+  assert(state != NULL);
+  if((state->probes = slist_alloc()) == NULL ||
+     (state->replies = malloc_zero(sizeof(slist_t *)*up->probe_count)) == NULL)
     {
       printerror(__func__, "could not alloc state");
-      goto err;
+      return -1;
+    }
+  for(i=0; i<up->probe_count; i++)
+    {
+      if((state->replies[i] = slist_alloc()) == NULL)
+	{
+	  printerror(__func__, "could not alloc state");
+	  return -1;
+	}
     }
 
-  if(SCAMPER_ADDR_TYPE_IS_IPV4(up->dst))
-    state->fdn = scamper_fd_udp4dg(up->src->addr, up->sport);
-  else if(SCAMPER_ADDR_TYPE_IS_IPV6(up->dst))
-    state->fdn = scamper_fd_udp6(up->src->addr, up->sport);
-  if(state->fdn == NULL)
-    goto err;
-
-  scamper_task_setstate(task, state);
-  return state;
-
- err:
-  if(state != NULL) udpprobe_state_free(state);
-  return NULL;
+  return 0;
 }
 
 static void do_udpprobe_probe(scamper_task_t *task)
 {
   scamper_udpprobe_t *up = udpprobe_getdata(task);
   udpprobe_state_t *state = udpprobe_getstate(task);
+  scamper_udpprobe_probe_t *probe = NULL;
   struct sockaddr_in6 sin6;
   struct sockaddr_in sin;
   struct sockaddr *sa;
-  struct timeval finish;
+  struct timeval wait_tv;
   socklen_t sl;
   int fd, ttl = 255;
   void *ttl_p = (void *)&ttl;
   size_t ttl_l = sizeof(ttl);
 
-  assert(state == NULL);
-
-  if((state = udpprobe_state_alloc(task)) == NULL)
+  if(state->probec == 0 && udpprobe_state_alloc(task) != 0)
     goto err;
-  fd = scamper_fd_fd_get(state->fdn);
+
+  fd = scamper_fd_fd_get(state->fds[state->probec]);
 
   if(SCAMPER_ADDR_TYPE_IS_IPV4(up->dst))
     {
@@ -202,11 +237,23 @@ static void do_udpprobe_probe(scamper_task_t *task)
     }
   else goto err;
 
-  gettimeofday_wrap(&up->start);
+  if((probe = scamper_udpprobe_probe_alloc()) == NULL ||
+     slist_tail_push(state->probes, probe) == NULL)
+    goto err;
+  gettimeofday_wrap(&probe->tx);
+  scamper_fd_sport(state->fds[state->probec], &probe->sport);
+  if(state->probec == 0)
+    timeval_cpy(&up->start, &probe->tx);
+  state->probec++;
+
   if(sendto(fd, up->data, up->len, 0, sa, sl) != up->len)
     goto err;
-  timeval_add_tv3(&finish, &up->start, &up->wait_timeout);
-  scamper_task_queue_wait_tv(task, &finish);
+
+  if(state->probec < up->probe_count)
+    timeval_add_tv3(&wait_tv, &probe->tx, &up->wait_probe);
+  else
+    timeval_add_tv3(&wait_tv, &probe->tx, &up->wait_timeout);
+  scamper_task_queue_wait_tv(task, &wait_tv);
 
   return;
 
@@ -217,7 +264,12 @@ static void do_udpprobe_probe(scamper_task_t *task)
 
 static void do_udpprobe_handle_timeout(scamper_task_t *task)
 {
-  udpprobe_stop(task, SCAMPER_UDPPROBE_STOP_DONE);
+  scamper_udpprobe_t *up = udpprobe_getdata(task);
+  udpprobe_state_t *state = udpprobe_getstate(task);
+
+  if(state->probec == up->probe_count)
+    udpprobe_stop(task, SCAMPER_UDPPROBE_STOP_DONE);
+
   return;
 }
 
@@ -241,7 +293,7 @@ static void do_udpprobe_free(scamper_task_t *task)
   udpprobe_state_t *state = udpprobe_getstate(task);
 
   if(state != NULL)
-    udpprobe_state_free(state);
+    udpprobe_state_free(up, state);
   if(up != NULL)
     scamper_udpprobe_free(up);
 
@@ -262,9 +314,15 @@ scamper_task_t *scamper_do_udpprobe_alloctask(void *data,
   scamper_udpprobe_t *up = (scamper_udpprobe_t *)data;
   scamper_task_t *task = NULL;
   scamper_task_sig_t *sig = NULL;
+  udpprobe_state_t *state = NULL;
+  uint16_t *sports = NULL;
+  uint8_t i, probec = up->probe_count;
 
   /* allocate a task structure and store the udpprobe with it */
-  if((task = scamper_task_alloc(up, &udpprobe_funcs)) == NULL)
+  if((task = scamper_task_alloc(up, &udpprobe_funcs)) == NULL ||
+     (state = malloc_zero(sizeof(udpprobe_state_t))) == NULL ||
+     (state->fds = malloc_zero(sizeof(scamper_fd_t *) * probec)) == NULL ||
+     (sports = malloc_zero(sizeof(uint16_t) * probec)) == NULL)
     {
       snprintf(errbuf, errlen, "%s: could not malloc state", __func__);
       goto err;
@@ -275,20 +333,46 @@ scamper_task_t *scamper_do_udpprobe_alloctask(void *data,
     goto err;
 
   /* declare the signature of the task's probes */
-  if((sig = scamper_task_sig_alloc(SCAMPER_TASK_SIG_TYPE_TX_IP)) == NULL)
+  for(i=0; i<up->probe_count; i++)
     {
-      snprintf(errbuf, errlen, "%s: could not alloc task signature", __func__);
-      goto err;
+      if(SCAMPER_ADDR_TYPE_IS_IPV4(up->dst))
+	state->fds[i] = scamper_fd_udp4dg_dst(up->src->addr, up->sport,
+					      sports, i,
+					      up->dst->addr, up->dport);
+      else if(SCAMPER_ADDR_TYPE_IS_IPV6(up->dst))
+	state->fds[i] = scamper_fd_udp6_dst(up->src->addr, up->sport,
+					    sports, i,
+					    up->dst->addr, up->dport);
+      if(state->fds[i] == NULL)
+	{
+	  snprintf(errbuf, errlen, "%s: could not open udp socket", __func__);
+	  goto err;
+	}
+      if(scamper_fd_sport(state->fds[i], &sports[i]) != 0)
+	{
+	  snprintf(errbuf, errlen, "%s: could not get udp sport", __func__);
+	  goto err;
+	}
+
+      if((sig = scamper_task_sig_alloc(SCAMPER_TASK_SIG_TYPE_TX_IP)) == NULL)
+	{
+	  snprintf(errbuf, errlen, "%s: could not alloc task signature", __func__);
+	  goto err;
+	}
+      sig->sig_tx_ip_dst = scamper_addr_use(up->dst);
+      sig->sig_tx_ip_src = scamper_addr_use(up->src);
+      SCAMPER_TASK_SIG_UDP(sig, sports[i], up->dport);
+      if(scamper_task_sig_add(task, sig) != 0)
+	{
+	  snprintf(errbuf, errlen, "%s: could not add signature to task", __func__);
+	  goto err;
+	}
+      sig = NULL;
     }
-  sig->sig_tx_ip_dst = scamper_addr_use(up->dst);
-  sig->sig_tx_ip_src = scamper_addr_use(up->src);
-  SCAMPER_TASK_SIG_UDP(sig, up->sport, up->dport);
-  if(scamper_task_sig_add(task, sig) != 0)
-    {
-      snprintf(errbuf, errlen, "%s: could not add signature to task", __func__);
-      goto err;
-    }
-  sig = NULL;
+
+  free(sports);
+
+  scamper_task_setstate(task, state);
 
   /* associate the list and cycle with the http structure */
   up->list = scamper_list_use(list);
@@ -298,6 +382,8 @@ scamper_task_t *scamper_do_udpprobe_alloctask(void *data,
 
  err:
   if(sig != NULL) scamper_task_sig_free(sig);
+  if(state != NULL) udpprobe_state_free(up, state);
+  if(sports != NULL) free(sports);
   if(task != NULL)
     {
       scamper_task_setdatanull(task);

--- a/scamper/udpprobe/scamper_udpprobe_int.h
+++ b/scamper/udpprobe/scamper_udpprobe_int.h
@@ -24,6 +24,7 @@
 #define __SCAMPER_UDPPROBE_INT_H
 
 scamper_udpprobe_t *scamper_udpprobe_alloc(void);
+scamper_udpprobe_probe_t *scamper_udpprobe_probe_alloc(void);
 scamper_udpprobe_reply_t *scamper_udpprobe_reply_alloc(void);
 
 #define SCAMPER_UDPPROBE_FLAG_EXITFIRST 0x01 /* return on first reply */
@@ -40,7 +41,18 @@ struct scamper_udpprobe_reply
 {
   uint8_t                   *data;
   uint16_t                   len;
-  struct timeval             tv;
+  struct timeval             rx;
+#ifdef BUILDING_LIBSCAMPERFILE
+  int                        refcnt;
+#endif
+};
+
+struct scamper_udpprobe_probe
+{
+  struct timeval             tx;
+  uint16_t                   sport;
+  scamper_udpprobe_reply_t **replies;
+  uint8_t                    replyc;
 #ifdef BUILDING_LIBSCAMPERFILE
   int                        refcnt;
 #endif
@@ -52,21 +64,24 @@ struct scamper_udpprobe
   scamper_cycle_t           *cycle;
   uint32_t                   userid;
 
+  /* probing parameters */
   scamper_addr_t            *src;
   scamper_addr_t            *dst;
   uint16_t                   sport;
   uint16_t                   dport;
+  uint8_t                    probe_count;
+  uint8_t                    stop_count;
   struct timeval             start;
   struct timeval             wait_timeout;
-
+  struct timeval             wait_probe;
   uint8_t                    flags;
-  uint8_t                    stop;
-
   uint8_t                   *data;
   uint16_t                   len;
 
-  scamper_udpprobe_reply_t **replies;
-  uint8_t                    replyc;
+  /* collected data */
+  uint8_t                    stop;
+  scamper_udpprobe_probe_t **probes;
+  uint8_t                    probe_sent;
 };
 
 #endif /* __SCAMPER_UDPPROBE_INT_H */

--- a/scamper/udpprobe/scamper_udpprobe_json.c
+++ b/scamper/udpprobe/scamper_udpprobe_json.c
@@ -35,25 +35,103 @@
 
 #include "utils.h"
 
-static char *reply_tostr(const scamper_udpprobe_t *up,
-			 const scamper_udpprobe_reply_t *ur)
+static char *reply_tostr(const scamper_udpprobe_probe_t *probe,
+			 const scamper_udpprobe_reply_t *reply,
+			 size_t *len)
 {
   struct timeval rtt;
   char buf[(65536 * 2) + 512];
   size_t off = 0;
   uint16_t i;
 
-  timeval_diff_tv(&rtt, &up->start, &ur->tv);
-  string_concat(buf, sizeof(buf), &off, "{\"rx\":{\"sec\":%ld,\"usec\":%d}",
-		(long)ur->tv.tv_sec, (int)ur->tv.tv_usec);
-  string_concat(buf, sizeof(buf), &off, ", \"rtt\":{\"sec\":%ld,\"usec\":%d}",
-		(long)rtt.tv_sec, (int)rtt.tv_usec);
-  string_concat(buf, sizeof(buf), &off, ", \"len\":%u, \"data\":\"", ur->len);
-  for(i=0; i<ur->len; i++)
-    string_concat(buf, sizeof(buf), &off, "%02x", ur->data[i]);
+  if(reply == NULL)
+    {
+      *len = 2;
+      return strdup("{}");
+    }
+
+  timeval_diff_tv(&rtt, &probe->tx, &reply->rx);
+  string_concat(buf, sizeof(buf), &off,
+		"{\"rx\":{\"sec\":%ld,\"usec\":%d}"
+		", \"rtt\":{\"sec\":%ld,\"usec\":%d}"
+		", \"len\":%u, \"data\":\"",
+		(long)reply->rx.tv_sec, (int)reply->rx.tv_usec,
+		(long)rtt.tv_sec, (int)rtt.tv_usec,
+		reply->len);
+  for(i=0; i<reply->len; i++)
+    string_concat(buf, sizeof(buf), &off, "%02x", reply->data[i]);
   string_concat(buf, sizeof(buf), &off, "\"}");
 
+  *len = off;
+
   return strdup(buf);
+}
+
+static char *probe_tostr(const scamper_udpprobe_probe_t *probe)
+{
+  char header[256], **replies = NULL, *str = NULL, *rc = NULL;
+  size_t len, wc = 0, header_len = 0, rl, *reply_lens = NULL;
+  uint16_t i;
+
+  if(probe == NULL)
+    return strdup("{}");
+
+  string_concat(header, sizeof(header), &header_len,
+		"{\"tx\":{\"sec\":%ld,\"usec\":%d}, \"sport\":%u,"
+		" \"replyc\":%u, \"replies\":[",
+		(long)probe->tx.tv_sec, (int)probe->tx.tv_usec,
+		probe->sport, probe->replyc);
+  len = header_len;
+
+  if(probe->replyc > 0)
+    {
+      if((replies = malloc_zero(sizeof(char *) * probe->replyc)) == NULL ||
+	 (reply_lens = malloc_zero(sizeof(size_t) * probe->replyc)) == NULL)
+	goto done;
+      for(i=0; i<probe->replyc; i++)
+	{
+	  if(i > 0) len += 2; /* , */
+	  if((replies[i] = reply_tostr(probe, probe->replies[i], &rl)) == NULL)
+	    goto done;
+	  reply_lens[i] = rl;
+	  len += rl;
+	}
+    }
+  len += 3; /* ]}\0 */
+
+  if((str = malloc_zero(len)) == NULL)
+    goto done;
+  memcpy(str, header, header_len); wc += header_len;
+  if(probe->replyc > 0)
+    {
+      for(i=0; i<probe->replyc; i++)
+	{
+	  if(i > 0)
+	    {
+	      memcpy(str+wc, ", ", 2);
+	      wc += 2;
+	    }
+	  memcpy(str+wc, replies[i], reply_lens[i]);
+	  wc += reply_lens[i];
+	}
+    }
+  memcpy(str+wc, "]}\0", 3); wc += 3;
+  assert(wc == len);
+
+  rc = str;
+
+ done:
+  if(rc == NULL && str != NULL)
+    free(str);
+  if(replies != NULL) {
+    for(i=0; i<probe->replyc; i++)
+      if(replies[i] != NULL)
+	free(replies[i]);
+    free(replies);
+  }
+  if(reply_lens != NULL)
+    free(reply_lens);
+  return rc;
 }
 
 static char *header_tostr(const scamper_udpprobe_t *up)
@@ -72,12 +150,11 @@ static char *header_tostr(const scamper_udpprobe_t *up)
     string_concat(buf, sizeof(buf), &off, ", \"dst\":\"%s\"",
 		  scamper_addr_tostr(up->dst, tmp, sizeof(tmp)));
   string_concat(buf, sizeof(buf), &off,
-		", \"userid\":%u, \"start\":{\"sec\":%ld,\"usec\":%d}",
-		up->userid, (long)up->start.tv_sec, (int)up->start.tv_usec);
-  string_concat(buf, sizeof(buf), &off,
-		", \"sport\":%u, \"dport\":%u", up->sport, up->dport);
-  string_concat(buf, sizeof(buf), &off,
+		", \"userid\":%u, \"start\":{\"sec\":%ld,\"usec\":%d}"
+		", \"sport\":%u, \"dport\":%u"
 		", \"wait_timeout\":{\"sec\":%ld,\"usec\":%d}",
+		up->userid, (long)up->start.tv_sec, (int)up->start.tv_usec,
+		up->sport, up->dport,
 		(long)up->wait_timeout.tv_sec, (int)up->wait_timeout.tv_usec);
 
   if(up->flags & SCAMPER_UDPPROBE_FLAG_EXITFIRST)
@@ -95,7 +172,9 @@ static char *header_tostr(const scamper_udpprobe_t *up)
     string_concat(buf, sizeof(buf), &off, "%02x", up->data[i]);
   string_concat(buf, sizeof(buf), &off, "\", \"len\":%u", up->len);
 
-  string_concat(buf, sizeof(buf), &off, ", \"replyc\":%u", up->replyc);
+  string_concat(buf, sizeof(buf), &off,
+		", \"probe_count\":%u, \"probe_sent\":%u, \"stop_count\":%u",
+		up->probe_count, up->probe_sent, up->stop_count);
 
   return strdup(buf);
 }
@@ -104,7 +183,7 @@ int scamper_file_json_udpprobe_write(const scamper_file_t *sf,
 				     const scamper_udpprobe_t *up, void *p)
 {
   char *header = NULL, *str = NULL;
-  char **replies = NULL; size_t *reply_lens = NULL;
+  char **probes = NULL; size_t *probe_lens = NULL;
   size_t len = 0, header_len = 0;
   size_t wc = 0;
   int ret = -1;
@@ -115,19 +194,19 @@ int scamper_file_json_udpprobe_write(const scamper_file_t *sf,
     goto cleanup;
   len = (header_len = strlen(header));
 
-  len += 13; /* , \"replies\":[ */
+  len += 12; /* , \"probes\":[ */
 
-  if(up->replyc > 0)
+  if(up->probe_sent > 0)
     {
-      if((replies = malloc_zero(sizeof(char *) * up->replyc)) == NULL ||
-	 (reply_lens = malloc_zero(sizeof(size_t) * up->replyc)) == NULL)
+      if((probes = malloc_zero(sizeof(char *) * up->probe_sent)) == NULL ||
+	 (probe_lens = malloc_zero(sizeof(size_t) * up->probe_sent)) == NULL)
 	goto cleanup;
-      for(i=0; i<up->replyc; i++)
+      for(i=0; i<up->probe_sent; i++)
 	{
 	  if(i > 0) len++; /* , */
-	  if((replies[i] = reply_tostr(up, up->replies[i])) == NULL)
+	  if((probes[i] = probe_tostr(up->probes[i])) == NULL)
 	    goto cleanup;
-	  len += (reply_lens[i] = strlen(replies[i]));
+	  len += (probe_lens[i] = strlen(probes[i]));
 	}
     }
 
@@ -136,14 +215,14 @@ int scamper_file_json_udpprobe_write(const scamper_file_t *sf,
   if((str = malloc_zero(len)) == NULL)
     goto cleanup;
   memcpy(str+wc, header, header_len); wc += header_len;
-  memcpy(str+wc, ", \"replies\":[", 13); wc += 13;
+  memcpy(str+wc, ", \"probes\":[", 12); wc += 12;
 
-  for(i=0; i<up->replyc; i++)
+  for(i=0; i<up->probe_sent; i++)
     {
       if(i > 0)
 	str[wc++] = ',';
-      memcpy(str+wc, replies[i], reply_lens[i]);
-      wc += reply_lens[i];
+      memcpy(str+wc, probes[i], probe_lens[i]);
+      wc += probe_lens[i];
     }
 
   memcpy(str+wc, "]}\n", 3); wc += 3;
@@ -154,13 +233,13 @@ int scamper_file_json_udpprobe_write(const scamper_file_t *sf,
  cleanup:
   if(header != NULL) free(header);
   if(str != NULL) free(str);
-  if(replies != NULL)
+  if(probes != NULL)
     {
-      for(i=0; i<up->replyc; i++)
-	if(replies[i] != NULL)
-	  free(replies[i]);
-      free(replies);
+      for(i=0; i<up->probe_sent; i++)
+	if(probes[i] != NULL)
+	  free(probes[i]);
+      free(probes);
     }
-  if(reply_lens != NULL) free(reply_lens);
+  if(probe_lens != NULL) free(probe_lens);
   return ret;
 }

--- a/scamper/udpprobe/scamper_udpprobe_json.c
+++ b/scamper/udpprobe/scamper_udpprobe_json.c
@@ -1,0 +1,166 @@
+/*
+ * scamper_udpprobe_json.c
+ *
+ * Author: Matthew Luckie
+ *
+ * $Id$
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "internal.h"
+
+#include "scamper_addr.h"
+#include "scamper_list.h"
+#include "scamper_udpprobe.h"
+#include "scamper_udpprobe_int.h"
+#include "scamper_file.h"
+#include "scamper_file_json.h"
+#include "scamper_udpprobe_json.h"
+
+#include "utils.h"
+
+static char *reply_tostr(const scamper_udpprobe_t *up,
+			 const scamper_udpprobe_reply_t *ur)
+{
+  struct timeval rtt;
+  char buf[(65536 * 2) + 512];
+  size_t off = 0;
+  uint16_t i;
+
+  timeval_diff_tv(&rtt, &up->start, &ur->tv);
+  string_concat(buf, sizeof(buf), &off, "{\"rx\":{\"sec\":%ld,\"usec\":%d}",
+		(long)ur->tv.tv_sec, (int)ur->tv.tv_usec);
+  string_concat(buf, sizeof(buf), &off, ", \"rtt\":{\"sec\":%ld,\"usec\":%d}",
+		(long)rtt.tv_sec, (int)rtt.tv_usec);
+  string_concat(buf, sizeof(buf), &off, ", \"len\":%u, \"data\":\"", ur->len);
+  for(i=0; i<ur->len; i++)
+    string_concat(buf, sizeof(buf), &off, "%02x", ur->data[i]);
+  string_concat(buf, sizeof(buf), &off, "\"}");
+
+  return strdup(buf);
+}
+
+static char *header_tostr(const scamper_udpprobe_t *up)
+{
+  static const char *stop_m[] = {"none", "done", "halted", "error"};
+  char buf[4096], tmp[512];
+  size_t off = 0;
+  uint16_t i;
+
+  string_concat(buf, sizeof(buf), &off,
+		"{\"type\":\"udpprobe\", \"version\":\"0.1\"");
+  if(up->src != NULL)
+    string_concat(buf, sizeof(buf), &off, ", \"src\":\"%s\"",
+		  scamper_addr_tostr(up->src, tmp, sizeof(tmp)));
+  if(up->dst != NULL)
+    string_concat(buf, sizeof(buf), &off, ", \"dst\":\"%s\"",
+		  scamper_addr_tostr(up->dst, tmp, sizeof(tmp)));
+  string_concat(buf, sizeof(buf), &off,
+		", \"userid\":%u, \"start\":{\"sec\":%ld,\"usec\":%d}",
+		up->userid, (long)up->start.tv_sec, (int)up->start.tv_usec);
+  string_concat(buf, sizeof(buf), &off,
+		", \"sport\":%u, \"dport\":%u", up->sport, up->dport);
+  string_concat(buf, sizeof(buf), &off,
+		", \"wait_timeout\":{\"sec\":%ld,\"usec\":%d}",
+		(long)up->wait_timeout.tv_sec, (int)up->wait_timeout.tv_usec);
+
+  if(up->flags & SCAMPER_UDPPROBE_FLAG_EXITFIRST)
+    string_concat(buf, sizeof(buf), &off, ", \"flags\":[\"exitfirst\"]");
+
+  string_concat(buf, sizeof(buf), &off, ", \"stop_reason\":\"");
+  if(up->stop >= sizeof(stop_m) / sizeof(char *))
+    string_concat(buf, sizeof(buf), &off, "%d", up->stop);
+  else
+    string_concat(buf, sizeof(buf), &off, "%s", stop_m[up->stop]);
+  string_concat(buf, sizeof(buf), &off, "\"");
+
+  string_concat(buf, sizeof(buf), &off, ", \"data\":\"");
+  for(i=0; i<up->len; i++)
+    string_concat(buf, sizeof(buf), &off, "%02x", up->data[i]);
+  string_concat(buf, sizeof(buf), &off, "\", \"len\":%u", up->len);
+
+  string_concat(buf, sizeof(buf), &off, ", \"replyc\":%u", up->replyc);
+
+  return strdup(buf);
+}
+
+int scamper_file_json_udpprobe_write(const scamper_file_t *sf,
+				     const scamper_udpprobe_t *up, void *p)
+{
+  char *header = NULL, *str = NULL;
+  char **replies = NULL; size_t *reply_lens = NULL;
+  size_t len = 0, header_len = 0;
+  size_t wc = 0;
+  int ret = -1;
+  uint8_t i;
+
+  /* get the header string */
+  if((header = header_tostr(up)) == NULL)
+    goto cleanup;
+  len = (header_len = strlen(header));
+
+  len += 13; /* , \"replies\":[ */
+
+  if(up->replyc > 0)
+    {
+      if((replies = malloc_zero(sizeof(char *) * up->replyc)) == NULL ||
+	 (reply_lens = malloc_zero(sizeof(size_t) * up->replyc)) == NULL)
+	goto cleanup;
+      for(i=0; i<up->replyc; i++)
+	{
+	  if(i > 0) len++; /* , */
+	  if((replies[i] = reply_tostr(up, up->replies[i])) == NULL)
+	    goto cleanup;
+	  len += (reply_lens[i] = strlen(replies[i]));
+	}
+    }
+
+  len += 3; /* ]}\n */
+
+  if((str = malloc_zero(len)) == NULL)
+    goto cleanup;
+  memcpy(str+wc, header, header_len); wc += header_len;
+  memcpy(str+wc, ", \"replies\":[", 13); wc += 13;
+
+  for(i=0; i<up->replyc; i++)
+    {
+      if(i > 0)
+	str[wc++] = ',';
+      memcpy(str+wc, replies[i], reply_lens[i]);
+      wc += reply_lens[i];
+    }
+
+  memcpy(str+wc, "]}\n", 3); wc += 3;
+
+  assert(wc == len);
+  ret = json_write(sf, str, len, p);
+
+ cleanup:
+  if(header != NULL) free(header);
+  if(str != NULL) free(str);
+  if(replies != NULL)
+    {
+      for(i=0; i<up->replyc; i++)
+	if(replies[i] != NULL)
+	  free(replies[i]);
+      free(replies);
+    }
+  if(reply_lens != NULL) free(reply_lens);
+  return ret;
+}

--- a/scamper/udpprobe/scamper_udpprobe_json.h
+++ b/scamper/udpprobe/scamper_udpprobe_json.h
@@ -1,0 +1,27 @@
+/*
+ * scamper_udpprobe_json.h
+ *
+ * $Id$
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#ifndef __SCAMPER_UDPPROBE_JSON_H
+#define __SCAMPER_UDPPROBE_JSON_H
+
+int scamper_file_json_udpprobe_write(const scamper_file_t *sf,
+				     const scamper_udpprobe_t *up, void *p);
+
+#endif /* __SCAMPER_UDPPROBE_JSON_H */

--- a/scamper/udpprobe/scamper_udpprobe_lib.c
+++ b/scamper/udpprobe/scamper_udpprobe_lib.c
@@ -78,6 +78,11 @@ const struct timeval *scamper_udpprobe_wait_timeout_get(const scamper_udpprobe_t
   return &udpp->wait_timeout;
 }
 
+const struct timeval *scamper_udpprobe_wait_probe_get(const scamper_udpprobe_t *udpp)
+{
+  return &udpp->wait_probe;
+}
+
 int scamper_udpprobe_flag_is_exitfirst(const scamper_udpprobe_t *udpp)
 {
   return SCAMPER_UDPPROBE_FLAG_IS_EXITFIRST(udpp);
@@ -91,18 +96,6 @@ const uint8_t *scamper_udpprobe_data_get(const scamper_udpprobe_t *up)
 uint16_t scamper_udpprobe_len_get(const scamper_udpprobe_t *up)
 {
   return up->len;
-}
-
-scamper_udpprobe_reply_t *scamper_udpprobe_reply_get(const scamper_udpprobe_t *up, uint8_t i)
-{
-  if(up->replies == NULL || i >= up->replyc)
-    return NULL;
-  return up->replies[i];
-}
-
-uint8_t scamper_udpprobe_replyc_get(const scamper_udpprobe_t *up)
-{
-  return up->replyc;
 }
 
 #ifdef BUILDING_LIBSCAMPERFILE
@@ -123,7 +116,51 @@ uint16_t scamper_udpprobe_reply_len_get(const scamper_udpprobe_reply_t *ur)
   return ur->len;
 }
 
-const struct timeval *scamper_udpprobe_reply_tv_get(const scamper_udpprobe_reply_t *ur)
+const struct timeval *scamper_udpprobe_reply_rx_get(const scamper_udpprobe_reply_t *ur)
 {
-  return &ur->tv;
+  return &ur->rx;
+}
+
+uint8_t scamper_udpprobe_probe_count_get(const scamper_udpprobe_t *up)
+{
+  return up->probe_count;
+}
+
+uint8_t scamper_udpprobe_probe_sent_get(const scamper_udpprobe_t *up)
+{
+  return up->probe_sent;
+}
+
+uint8_t scamper_udpprobe_stop_count_get(const scamper_udpprobe_t *up)
+{
+  return up->stop_count;
+}
+
+scamper_udpprobe_probe_t *scamper_udpprobe_probe_get(const scamper_udpprobe_t *up, uint8_t i)
+{
+  if(up->probes == NULL || i >= up->probe_sent)
+    return NULL;
+  return up->probes[i];
+}
+
+const struct timeval *scamper_udpprobe_probe_tx_get(const scamper_udpprobe_probe_t *probe)
+{
+  return &probe->tx;
+}
+
+uint16_t scamper_udpprobe_probe_sport_get(const scamper_udpprobe_probe_t *probe)
+{
+  return probe->sport;
+}
+
+scamper_udpprobe_reply_t *scamper_udpprobe_probe_reply_get(const scamper_udpprobe_probe_t *probe, uint8_t i)
+{
+  if(probe->replies == NULL || i >= probe->replyc)
+    return NULL;
+  return probe->replies[i];
+}
+
+uint8_t scamper_udpprobe_probe_replyc_get(const scamper_udpprobe_probe_t *probe)
+{
+  return probe->replyc;
 }

--- a/scamper/udpprobe/scamper_udpprobe_warts.c
+++ b/scamper/udpprobe/scamper_udpprobe_warts.c
@@ -44,15 +44,20 @@
 #define WARTS_UDPPROBE_USERID          3
 #define WARTS_UDPPROBE_SRC             4
 #define WARTS_UDPPROBE_DST             5
-#define WARTS_UDPPROBE_SPORT           6
+#define WARTS_UDPPROBE_P0_SPORT        6
 #define WARTS_UDPPROBE_DPORT           7
 #define WARTS_UDPPROBE_START           8
-#define WARTS_UDPPROBE_TIMEOUT         9
+#define WARTS_UDPPROBE_WAIT_TIMEOUT    9
 #define WARTS_UDPPROBE_FLAGS           10
 #define WARTS_UDPPROBE_STOP            11
 #define WARTS_UDPPROBE_LEN             12
 #define WARTS_UDPPROBE_DATA            13
-#define WARTS_UDPPROBE_REPLYC          14
+#define WARTS_UDPPROBE_P0_REPLYC       14
+#define WARTS_UDPPROBE_PROBE_COUNT     15
+#define WARTS_UDPPROBE_PROBE_SENT      16
+#define WARTS_UDPPROBE_STOP_COUNT      17
+#define WARTS_UDPPROBE_SPORT           18
+#define WARTS_UDPPROBE_WAIT_PROBE      19
 
 static const warts_var_t udpprobe_vars[] =
 {
@@ -61,25 +66,30 @@ static const warts_var_t udpprobe_vars[] =
   {WARTS_UDPPROBE_USERID,       4},
   {WARTS_UDPPROBE_SRC,         -1},
   {WARTS_UDPPROBE_DST,         -1},
-  {WARTS_UDPPROBE_SPORT,        2},
+  {WARTS_UDPPROBE_P0_SPORT,     2},
   {WARTS_UDPPROBE_DPORT,        2},
   {WARTS_UDPPROBE_START,        8},
-  {WARTS_UDPPROBE_TIMEOUT,      4},
+  {WARTS_UDPPROBE_WAIT_TIMEOUT, 4},
   {WARTS_UDPPROBE_FLAGS,        1},
   {WARTS_UDPPROBE_STOP,         1},
   {WARTS_UDPPROBE_LEN,          2},
   {WARTS_UDPPROBE_DATA,        -1},
-  {WARTS_UDPPROBE_REPLYC,       1},
+  {WARTS_UDPPROBE_P0_REPLYC,    1},
+  {WARTS_UDPPROBE_PROBE_COUNT,  1},
+  {WARTS_UDPPROBE_PROBE_SENT,   1},
+  {WARTS_UDPPROBE_STOP_COUNT,   1},
+  {WARTS_UDPPROBE_SPORT,        2},
+  {WARTS_UDPPROBE_WAIT_PROBE,   4},
 };
 #define udpprobe_vars_mfb WARTS_VAR_MFB(udpprobe_vars)
 
-#define WARTS_UDPPROBE_REPLY_TV        1
+#define WARTS_UDPPROBE_REPLY_RX        1
 #define WARTS_UDPPROBE_REPLY_LEN       2
 #define WARTS_UDPPROBE_REPLY_DATA      3
 
 static const warts_var_t udpprobe_reply_vars[] =
 {
-  {WARTS_UDPPROBE_REPLY_TV,     8},
+  {WARTS_UDPPROBE_REPLY_RX,     8},
   {WARTS_UDPPROBE_REPLY_LEN,    2},
   {WARTS_UDPPROBE_REPLY_DATA,  -1},
 };
@@ -92,6 +102,85 @@ typedef struct warts_udpprobe_reply
   uint16_t  params_len;
   uint16_t  len;
 } warts_udpprobe_reply_t;
+
+#define WARTS_UDPPROBE_PROBE_TX     1
+#define WARTS_UDPPROBE_PROBE_SPORT  2
+#define WARTS_UDPPROBE_PROBE_REPLYC 3
+static const warts_var_t udpprobe_probe_vars[] =
+{
+  {WARTS_UDPPROBE_PROBE_TX,      8},
+  {WARTS_UDPPROBE_PROBE_SPORT,   2},
+  {WARTS_UDPPROBE_PROBE_REPLYC,  1},
+};
+#define udpprobe_probe_vars_mfb WARTS_VAR_MFB(udpprobe_probe_vars)
+
+typedef struct warts_udpprobe_probe
+{
+  uint8_t   flags[WARTS_VAR_MFB(udpprobe_probe_vars)];
+  uint16_t  flags_len;
+  uint16_t  params_len;
+  uint16_t  len;
+} warts_udpprobe_probe_t;
+
+static int warts_udpprobe_probe_params(const scamper_udpprobe_probe_t *up,
+				       warts_udpprobe_probe_t *state)
+{
+  const warts_var_t *var;
+  uint16_t u16;
+  int max_id = 0;
+  size_t i;
+
+  memset(state->flags, 0, udpprobe_probe_vars_mfb);
+  state->params_len = 0;
+
+  for(i=0; i<sizeof(udpprobe_probe_vars)/sizeof(warts_var_t); i++)
+    {
+      var = &udpprobe_probe_vars[i];
+      if(var->id == WARTS_UDPPROBE_PROBE_REPLYC && up->replyc == 0)
+	continue;
+      flag_set(state->flags, var->id, &max_id);
+      assert(var->size > 0);
+      u16 = var->size;
+      if(uint16_wouldwrap(state->params_len, u16))
+	return -1;
+      state->params_len += u16;
+    }
+
+  state->flags_len = fold_flags(state->flags, max_id);
+  state->len = state->flags_len + state->params_len;
+  if(state->params_len != 0)
+    state->len += 2;
+  return 0;
+}
+
+static int warts_udpprobe_probe_read(scamper_udpprobe_probe_t *probe,
+				     const uint8_t *buf,
+				     uint32_t *off, uint32_t len)
+{
+  warts_param_reader_t handlers[] = {
+    {&probe->tx,     (wpr_t)extract_timeval,       NULL},
+    {&probe->sport,  (wpr_t)extract_uint16,        NULL},
+    {&probe->replyc, (wpr_t)extract_byte,          NULL},
+  };
+  const int handler_cnt = sizeof(handlers)/sizeof(warts_param_reader_t);
+  return warts_params_read(buf, off, len, handlers, handler_cnt);
+}
+
+static void warts_udpprobe_probe_write(const scamper_udpprobe_probe_t *probe,
+				       uint8_t *buf,
+				       uint32_t *off, uint32_t len,
+				       warts_udpprobe_probe_t *state)
+{
+  warts_param_writer_t handlers[] = {
+    {&probe->tx,     (wpw_t)insert_timeval,       NULL},
+    {&probe->sport,  (wpw_t)insert_uint16,        NULL},
+    {&probe->replyc, (wpw_t)insert_byte,          NULL},
+  };
+  const int handler_cnt = sizeof(handlers)/sizeof(warts_param_reader_t);
+  warts_params_write(buf, off, len, state->flags, state->flags_len,
+		     state->params_len, handlers, handler_cnt);
+  return;
+}
 
 static int warts_udpprobe_reply_params(const scamper_udpprobe_reply_t *ur,
 				       warts_udpprobe_reply_t *state)
@@ -107,7 +196,7 @@ static int warts_udpprobe_reply_params(const scamper_udpprobe_reply_t *ur,
   for(i=0; i<sizeof(udpprobe_reply_vars)/sizeof(warts_var_t); i++)
     {
       var = &udpprobe_reply_vars[i];
-      if((var->id == WARTS_UDPPROBE_REPLY_TV && timeval_iszero(&ur->tv)) ||
+      if((var->id == WARTS_UDPPROBE_REPLY_RX && timeval_iszero(&ur->rx)) ||
 	 ((var->id == WARTS_UDPPROBE_REPLY_LEN ||
 	   var->id == WARTS_UDPPROBE_REPLY_DATA) &&
 	  (ur->data == NULL || ur->len == 0)))
@@ -141,7 +230,7 @@ static int warts_udpprobe_reply_read(scamper_udpprobe_reply_t *ur,
 				     uint32_t *off, uint32_t len)
 {
   warts_param_reader_t handlers[] = {
-    {&ur->tv,   (wpr_t)extract_timeval,       NULL},
+    {&ur->rx,   (wpr_t)extract_timeval,       NULL},
     {&ur->len,  (wpr_t)extract_uint16,        NULL},
     {&ur->data, (wpr_t)extract_bytes_alloc,   &ur->len},
   };
@@ -156,7 +245,7 @@ static void warts_udpprobe_reply_write(const scamper_udpprobe_reply_t *ur,
 {
   uint16_t ur_len = ur->len;
   warts_param_writer_t handlers[] = {
-    {&ur->tv,   (wpw_t)insert_timeval,       NULL},
+    {&ur->rx,   (wpw_t)insert_timeval,       NULL},
     {&ur->len,  (wpw_t)insert_uint16,        NULL},
     {ur->data,  (wpw_t)insert_bytes_uint16, &ur_len},
   };
@@ -186,15 +275,26 @@ static int warts_udpprobe_params(const scamper_udpprobe_t *up, uint8_t *flags,
 	 (var->id == WARTS_UDPPROBE_USERID  && up->userid == 0) ||
 	 (var->id == WARTS_UDPPROBE_SRC     && up->src == NULL) ||
 	 (var->id == WARTS_UDPPROBE_DST     && up->dst == NULL) ||
-	 (var->id == WARTS_UDPPROBE_SPORT   && up->sport == 0) ||
+	 (var->id == WARTS_UDPPROBE_P0_SPORT &&
+	  (up->probes == NULL || up->probe_sent == 0 ||
+	   up->probes[0] == NULL)) ||
 	 (var->id == WARTS_UDPPROBE_DPORT   && up->dport == 0) ||
 	 (var->id == WARTS_UDPPROBE_START   && timeval_iszero(&up->start)) ||
-	 (var->id == WARTS_UDPPROBE_TIMEOUT && timeval_iszero(&up->wait_timeout)) ||
+	 (var->id == WARTS_UDPPROBE_WAIT_TIMEOUT &&
+	  timeval_iszero(&up->wait_timeout)) ||
+	 (var->id == WARTS_UDPPROBE_WAIT_PROBE &&
+	  timeval_iszero(&up->wait_probe)) ||
 	 (var->id == WARTS_UDPPROBE_FLAGS   && up->flags == 0) ||
 	 (var->id == WARTS_UDPPROBE_STOP    && up->stop == 0) ||
 	 ((var->id == WARTS_UDPPROBE_LEN || var->id == WARTS_UDPPROBE_DATA) &&
 	  (up->data == NULL || up->len == 0)) ||
-	 (var->id == WARTS_UDPPROBE_REPLYC  && up->replyc == 0))
+	 (var->id == WARTS_UDPPROBE_P0_REPLYC &&
+	  (up->probes == NULL || up->probe_sent == 0 || up->probes[0] == NULL ||
+	   up->probes[0]->replyc == 0)) ||
+	 (var->id == WARTS_UDPPROBE_PROBE_COUNT && up->probe_count == 1) ||
+	 (var->id == WARTS_UDPPROBE_PROBE_SENT && up->probe_sent == 1) ||
+	 (var->id == WARTS_UDPPROBE_STOP_COUNT && up->stop_count == 0) ||
+	 (var->id == WARTS_UDPPROBE_SPORT && up->sport == 0))
 	continue;
 
       /* Set the flag for the rest of the variables */
@@ -227,6 +327,7 @@ static int warts_udpprobe_params(const scamper_udpprobe_t *up, uint8_t *flags,
 }
 
 static int warts_udpprobe_params_read(scamper_udpprobe_t *up,
+				      uint8_t *p0_replyc, uint16_t *p0_sport,
 				      warts_state_t *state, uint8_t *buf,
 				      uint32_t *off, uint32_t len)
 {
@@ -236,7 +337,7 @@ static int warts_udpprobe_params_read(scamper_udpprobe_t *up,
     {&up->userid,       (wpr_t)extract_uint32,       NULL},
     {&up->src,          (wpr_t)extract_addr_static,  NULL},
     {&up->dst,          (wpr_t)extract_addr_static,  NULL},
-    {&up->sport,        (wpr_t)extract_uint16,       NULL},
+    {p0_sport,          (wpr_t)extract_uint16,       NULL},
     {&up->dport,        (wpr_t)extract_uint16,       NULL},
     {&up->start,        (wpr_t)extract_timeval,      NULL},
     {&up->wait_timeout, (wpr_t)extract_rtt,          NULL},
@@ -244,20 +345,22 @@ static int warts_udpprobe_params_read(scamper_udpprobe_t *up,
     {&up->stop,         (wpr_t)extract_byte,         NULL},
     {&up->len,          (wpr_t)extract_uint16,       NULL},
     {&up->data,         (wpr_t)extract_bytes_alloc,  &up->len},
-    {&up->replyc,       (wpr_t)extract_byte,         NULL},
+    {p0_replyc,         (wpr_t)extract_byte,         NULL},
+    {&up->probe_count,  (wpr_t)extract_byte,         NULL},
+    {&up->probe_sent,   (wpr_t)extract_byte,         NULL},
+    {&up->stop_count,   (wpr_t)extract_byte,         NULL},
+    {&up->sport,        (wpr_t)extract_uint16,       NULL},
+    {&up->wait_probe,   (wpr_t)extract_rtt,          NULL},
   };
   const int handler_cnt = sizeof(handlers) / sizeof(warts_param_reader_t);
-  size_t x;
 
   if(warts_params_read(buf, off, len, handlers, handler_cnt) != 0)
     return -1;
 
-  if(up->replyc > 0)
-    {
-      x = sizeof(scamper_udpprobe_reply_t *) * up->replyc;
-      if((up->replies = malloc_zero(x)) == NULL)
-	return -1;
-    }
+  if(up->probe_sent == 0)
+    up->probe_sent = 1;
+  if(up->probe_count == 0)
+    up->probe_count = 1;
 
   return 0;
 }
@@ -272,13 +375,14 @@ static int warts_udpprobe_params_write(const scamper_udpprobe_t *up,
 {
   uint16_t up_len = up->len;
   uint32_t list_id, cycle_id;
+  uint8_t p0_replyc = 0, p0_sport = 0;
   warts_param_writer_t handlers[] = {
     {&list_id,            (wpw_t)insert_uint32,       NULL},
     {&cycle_id,           (wpw_t)insert_uint32,       NULL},
     {&up->userid,         (wpw_t)insert_uint32,       NULL},
     {up->src,             (wpw_t)insert_addr_static,  NULL},
     {up->dst,             (wpw_t)insert_addr_static,  NULL},
-    {&up->sport,          (wpw_t)insert_uint16,       NULL},
+    {&p0_sport,           (wpw_t)insert_uint16,       NULL},
     {&up->dport,          (wpw_t)insert_uint16,       NULL},
     {&up->start,          (wpw_t)insert_timeval,      NULL},
     {&up->wait_timeout,   (wpw_t)insert_rtt,          NULL},
@@ -286,12 +390,23 @@ static int warts_udpprobe_params_write(const scamper_udpprobe_t *up,
     {&up->stop,           (wpw_t)insert_byte,         NULL},
     {&up->len,            (wpw_t)insert_uint16,       NULL},
     {up->data,            (wpw_t)insert_bytes_uint16, &up_len},
-    {&up->replyc,         (wpw_t)insert_byte,         NULL},
+    {&p0_replyc,          (wpw_t)insert_byte,         NULL},
+    {&up->probe_count,    (wpw_t)insert_byte,         NULL},
+    {&up->probe_sent,     (wpw_t)insert_byte,         NULL},
+    {&up->stop_count,     (wpw_t)insert_byte,         NULL},
+    {&up->sport,          (wpw_t)insert_uint16,       NULL},
+    {&up->wait_probe,     (wpw_t)insert_rtt,          NULL},
   };
   const int handler_cnt = sizeof(handlers)/sizeof(warts_param_writer_t);
 
   if(warts_list_getid(sf,  up->list,  &list_id)  == -1) return -1;
   if(warts_cycle_getid(sf, up->cycle, &cycle_id) == -1) return -1;
+
+  if(up->probes != NULL && up->probe_sent > 0 && up->probes[0] != NULL)
+    {
+      p0_replyc = up->probes[0]->replyc;
+      p0_sport  = up->probes[0]->sport;
+    }
 
   warts_params_write(buf, off, len, flags, flags_len, params_len, handlers,
 		     handler_cnt);
@@ -304,9 +419,13 @@ int scamper_file_warts_udpprobe_read(scamper_file_t *sf,
 {
   warts_state_t *state = scamper_file_getstate(sf);
   scamper_udpprobe_t *up = NULL;
+  scamper_udpprobe_probe_t *probe;
   uint8_t *buf = NULL;
-  uint32_t i, off = 0;
+  uint32_t off = 0, pN_urc = 0, px;
+  uint8_t i, j, p0_replyc = 0;
+  uint16_t p0_sport = 0;
   int rc = -1;
+  size_t x;
 
   if(warts_read(sf, &buf, hdr->len) != 0)
     goto done;
@@ -320,16 +439,76 @@ int scamper_file_warts_udpprobe_read(scamper_file_t *sf,
   if((up = scamper_udpprobe_alloc()) == NULL)
     goto done;
 
-  if(warts_udpprobe_params_read(up, state, buf, &off, hdr->len) != 0)
+  if(warts_udpprobe_params_read(up, &p0_replyc, &p0_sport, state, buf, &off, hdr->len) != 0)
     goto done;
 
-  if(up->replyc > 0)
+  if(up->probe_sent == 0)
+    up->probe_sent = 1;
+  if(up->probe_count == 0)
+    up->probe_count = 1;
+
+  x = sizeof(scamper_udpprobe_probe_t *) * up->probe_sent;
+  if((up->probes = malloc_zero(x)) == NULL ||
+     (up->probes[0] = scamper_udpprobe_probe_alloc()) == NULL)
+    goto done;
+  probe = up->probes[0];
+  probe->sport = p0_sport;
+  probe->replyc = p0_replyc;
+  timeval_cpy(&probe->tx, &up->start);
+
+  if(p0_replyc > 0)
     {
-      for(i=0; i<up->replyc; i++)
+      x = sizeof(scamper_udpprobe_reply_t *) * p0_replyc;
+      if((probe->replies = malloc_zero(x)) == NULL)
+	goto done;
+      for(i=0; i<p0_replyc; i++)
 	{
-	  if((up->replies[i] = scamper_udpprobe_reply_alloc()) == NULL ||
-	     warts_udpprobe_reply_read(up->replies[i], buf,&off,hdr->len) != 0)
+	  if((probe->replies[i] = scamper_udpprobe_reply_alloc()) == NULL ||
+	     warts_udpprobe_reply_read(probe->replies[i], buf,
+				       &off, hdr->len) != 0)
 	    goto done;
+	}
+    }
+
+  if(up->probe_sent > 1)
+    {
+      for(i=1; i<up->probe_sent; i++)
+	{
+	  if((up->probes[i] = scamper_udpprobe_probe_alloc()) == NULL ||
+	     warts_udpprobe_probe_read(up->probes[i], buf,
+				       &off, hdr->len) != 0)
+	    goto done;
+	  probe = up->probes[i];
+	  pN_urc += probe->replyc;
+	  if(probe->replyc > 0)
+	    {
+	      x = sizeof(scamper_udpprobe_reply_t *) * probe->replyc;
+	      if((probe->replies = malloc_zero(x)) == NULL)
+		goto done;
+	    }
+	}
+
+      if(pN_urc > 0)
+	{
+	  i = 1; j = 0;
+	  for(px=0; px<pN_urc; px++)
+	    {
+	      while(i < up->probe_sent)
+		{
+		  if(j < up->probes[i]->replyc)
+		    break;
+		  i++; j=0;
+		}
+	      if(i == up->probe_sent)
+		goto done;
+
+	      probe = up->probes[i];
+	      if((probe->replies[j] = scamper_udpprobe_reply_alloc()) == NULL ||
+		 warts_udpprobe_reply_read(probe->replies[j], buf,
+					   &off, hdr->len) != 0)
+		goto done;
+	      j++;
+	    }
 	}
     }
 
@@ -345,11 +524,14 @@ int scamper_file_warts_udpprobe_read(scamper_file_t *sf,
 int scamper_file_warts_udpprobe_write(const scamper_file_t *sf,
 				      const scamper_udpprobe_t *up, void *p)
 {
-  warts_udpprobe_reply_t *urs = NULL;
+  scamper_udpprobe_probe_t *p0 = NULL, *probe;
+  warts_udpprobe_reply_t *p0_urs = NULL;
+  warts_udpprobe_probe_t *pN_ups = NULL;
+  warts_udpprobe_reply_t *pN_urs = NULL;
   uint8_t *buf = NULL;
   uint8_t  flags[udpprobe_vars_mfb];
   uint16_t flags_len, params_len;
-  uint32_t len, off = 0;
+  uint32_t j, x, pN_urc = 0, len, off = 0;
   uint8_t i;
   int rc = -1;
 
@@ -357,16 +539,56 @@ int scamper_file_warts_udpprobe_write(const scamper_file_t *sf,
     goto done;
   len = 8 + flags_len + params_len + 2;
 
-  if(up->replyc > 0)
+  /*
+   * for backwards compatibility, handle details of the first probe
+   * separately to the remaining probes.
+   */
+  if(up->probes != NULL && up->probe_sent > 0 && up->probes[0] != NULL &&
+     up->probes[0]->replyc > 0)
     {
-      urs = malloc_zero(sizeof(warts_udpprobe_reply_t) * up->replyc);
-      if(urs == NULL)
+      p0 = up->probes[0];
+      p0_urs = malloc_zero(sizeof(warts_udpprobe_reply_t) * p0->replyc);
+      if(p0_urs == NULL)
 	goto done;
-      for(i=0; i<up->replyc; i++)
+      for(i=0; i<p0->replyc; i++)
 	{
-	  if(warts_udpprobe_reply_params(up->replies[i], &urs[i]) != 0)
+	  if(warts_udpprobe_reply_params(p0->replies[i], &p0_urs[i]) != 0)
 	    goto done;
-	  len += urs[i].len;
+	  len += p0_urs[i].len;
+	}
+    }
+
+  /* for all N additional probes/replies, deal with them here */
+  if(up->probe_sent > 1)
+    {
+      pN_ups = malloc_zero(sizeof(warts_udpprobe_probe_t) * (up->probe_sent-1));
+      if(pN_ups == NULL)
+	goto done;
+      for(i=1; i<up->probe_sent; i++)
+	{
+	  if(warts_udpprobe_probe_params(up->probes[i], &pN_ups[i-1]) != 0)
+	    goto done;
+	  len += pN_ups[i-1].len;
+	  pN_urc += up->probes[i]->replyc;
+	}
+      if(pN_urc > 0)
+	{
+	  pN_urs = malloc_zero(sizeof(warts_udpprobe_reply_t) * pN_urc);
+	  if(pN_urs == NULL)
+	    goto done;
+	  x = 0;
+	  for(i=1; i<up->probe_sent; i++)
+	    {
+	      probe = up->probes[i];
+	      for(j=0; j<probe->replyc; j++)
+		{
+		  if(warts_udpprobe_reply_params(probe->replies[j],
+						 &pN_urs[x]) != 0)
+		    goto done;
+		  len += pN_urs[x].len;
+		  x++;
+		}
+	    }
 	}
     }
 
@@ -381,10 +603,30 @@ int scamper_file_warts_udpprobe_write(const scamper_file_t *sf,
       goto done;
     }
 
-  if(up->replyc > 0)
+  if(p0 != NULL)
     {
-      for(i=0; i<up->replyc; i++)
-	warts_udpprobe_reply_write(up->replies[i], buf, &off, len, &urs[i]);
+      for(i=0; i<p0->replyc; i++)
+	warts_udpprobe_reply_write(p0->replies[i], buf, &off, len, &p0_urs[i]);
+    }
+
+  if(up->probe_sent > 1)
+    {
+      for(i=1; i<up->probe_sent; i++)
+	warts_udpprobe_probe_write(up->probes[i], buf, &off, len, &pN_ups[i-1]);
+      if(pN_urc > 0)
+	{
+	  x = 0;
+	  for(i=1; i<up->probe_sent; i++)
+	    {
+	      probe = up->probes[i];
+	      for(j=0; j<probe->replyc; j++)
+		{
+		  warts_udpprobe_reply_write(probe->replies[j],
+					     buf, &off, len, &pN_urs[x]);
+		  x++;
+		}
+	    }
+	}
     }
 
   assert(off == len);
@@ -395,7 +637,9 @@ int scamper_file_warts_udpprobe_write(const scamper_file_t *sf,
   rc = 0;
 
  done:
-  if(urs != NULL) free(urs);
+  if(p0_urs != NULL) free(p0_urs);
+  if(pN_urs != NULL) free(pN_urs);
+  if(pN_ups != NULL) free(pN_ups);
   if(buf != NULL) free(buf);
   return rc;
 }


### PR DESCRIPTION
udpprobe will create a separate socket for each probe, to allow for probe/response matching.  i modified the scamper_fd code to follow a similar approach as for TCP probing when we need multiple src-ports per destination, to minimize the total number of open sockets.