### PR TITLE
Update 20240716

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Build macOS binary
         # TODO: figure out how to get earthly working in macos
         run: |
-          export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
+          export PATH="$(brew --prefix)/opt/gnu-sed/libexec/gnubin:$PATH"
           git_hash=$(git rev-parse --short "$GITHUB_SHA")
           version="$(grep SCAMPER_VERSION scamper/scamper.h | cut -d \" -f 2)-${GITHUB_REF_NAME}.${git_hash}"
           ./set-version.sh ${version}

--- a/build-man-pdfs.pl
+++ b/build-man-pdfs.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 #
-# $Id: build-man-pdfs.pl,v 1.22 2023/04/10 07:45:38 mjl Exp $
+# $Id: build-man-pdfs.pl,v 1.23 2024/07/09 22:05:41 mjl Exp $
 
 use strict;
 use warnings;
@@ -24,6 +24,7 @@ my @mans = ("scamper/scamper.1",
 	    "utils/sc_filterpolicy/sc_filterpolicy.1",
 	    "utils/sc_hoiho/sc_hoiho.1",
 	    "utils/sc_ipiddump/sc_ipiddump.1",
+	    "utils/sc_minrtt/sc_minrtt.1",
 	    "utils/sc_pinger/sc_pinger.1",
 	    "utils/sc_prefixprober/sc_prefixprober.1",
 	    "utils/sc_prefixscan/sc_prefixscan.1",

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # Process this file with autoconf to produce a configure script.
 
-AC_INIT([scamper],[20240229],[mjl@luckie.org.nz])
+AC_INIT([scamper],[20240716],[mjl@luckie.org.nz])
 
 AC_CONFIG_SRCDIR([scamper/scamper.c])
 AC_CONFIG_AUX_DIR([.])
@@ -12,7 +12,6 @@ AM_MAINTAINER_MODE([disable])
 
 LT_INIT
 AC_PROG_CC
-AC_PROG_GCC_TRADITIONAL
 AC_PROG_INSTALL
 AC_PROG_MKDIR_P
 AC_LANG(C)
@@ -252,13 +251,21 @@ if test "x$with_python" = xyes; then
 fi
 AM_CONDITIONAL([ENABLE_PYTHON], [test x$with_python = xyes])
 
-# sc_hoiho utlity
+# sc_hoiho utility
 AC_ARG_ENABLE([sc_hoiho],
   [AS_HELP_STRING([--enable-sc_hoiho], [enable support for sc_hoiho])],
   [enable_sc_hoiho=$enableval],
   [enable_sc_hoiho=no]
 )
 AM_CONDITIONAL([ENABLE_SC_HOIHO], [test x$enable_sc_hoiho = xyes])
+
+# sc_minrtt utility
+AC_ARG_ENABLE([sc_minrtt],
+  [AS_HELP_STRING([--enable-sc_minrtt], [enable support for sc_minrtt])],
+  [enable_sc_minrtt=$enableval],
+  [enable_sc_minrtt=no]
+)
+AM_CONDITIONAL([ENABLE_SC_MINRTT], [test x$enable_sc_minrtt = xyes])
 
 # sc_uptime prober support
 AC_ARG_ENABLE([sc_uptime],
@@ -420,7 +427,7 @@ AC_CHECK_MEMBER([struct sockaddr.sa_len],
 	[#include <sys/types.h>
 	 #include <sys/socket.h>])
 
-if test "x$ac_cv_header_net_pfvar_h" == xyes; then
+if test "x$ac_cv_header_net_pfvar_h" = xyes; then
    AC_CHECK_MEMBER([struct pfioc_trans_e.type],
 	[AC_DEFINE([HAVE_STRUCT_PFIOC_TRANS_E_TYPE],[1],
 	[Define if struct pfioc_trans_e has a type member])],[:],
@@ -452,7 +459,7 @@ if test "x$ac_cv_header_net_pfvar_h" == xyes; then
 	 #include <sys/socket.h>
 	 #include <netinet/in.h>
 	 #include <net/if.h>
-	 #include <net/pfvar.h>]) 
+	 #include <net/pfvar.h>])
 fi
 
 # Check for structs
@@ -873,7 +880,8 @@ AC_CONFIG_FILES([
 	utils/sc_analysis_dump/Makefile
 	utils/sc_attach/Makefile
 	utils/sc_bdrmap/Makefile
-	utils/sc_erosprober/Makefile])
+	utils/sc_erosprober/Makefile
+	utils/sc_filterpolicy/Makefile])
 
 AM_COND_IF([ENABLE_SC_HOIHO],
 	[AC_CONFIG_FILES([
@@ -881,8 +889,14 @@ AM_COND_IF([ENABLE_SC_HOIHO],
 	])])
 
 AC_CONFIG_FILES([
-	utils/sc_filterpolicy/Makefile
-	utils/sc_ipiddump/Makefile
+	utils/sc_ipiddump/Makefile])
+
+AM_COND_IF([ENABLE_SC_MINRTT],
+	[AC_CONFIG_FILES([
+	utils/sc_minrtt/Makefile
+	])])
+
+AC_CONFIG_FILES([
 	utils/sc_pinger/Makefile
 	utils/sc_prefixprober/Makefile
 	utils/sc_prefixscan/Makefile

--- a/internal.h
+++ b/internal.h
@@ -1,7 +1,7 @@
 /*
  * internal.h
  *
- * $Id: internal.h,v 1.62 2024/02/28 02:11:53 mjl Exp $
+ * $Id: internal.h,v 1.66 2024/04/22 09:04:23 mjl Exp $
  *
  *        Matthew Luckie
  *        mjl@luckie.org.nz
@@ -10,7 +10,7 @@
  * Copyright (C) 2006-2011 The University of Waikato
  * Copyright (C) 2013-2015 The Regents of the University of California
  * Copyright (C) 2014-2016 Matthew Luckie
- * Copyright (C) 2023      Matthew Luckie
+ * Copyright (C) 2023-2024 Matthew Luckie
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,6 +30,14 @@
 #ifdef _WIN32 /* use rand_s on windows */
 #define _CRT_RAND_S
 #define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#if defined(__linux__)
+/*
+ * the following is necessary to get struct in6_pktinfo on modern
+ * (2024) linux systems.
+ */
+#define _GNU_SOURCE
 #endif
 
 #if defined(_MSC_VER)
@@ -70,6 +78,7 @@ typedef unsigned short sa_family_t;
 #define _BSD_SOCKLEN_T_
 #define HAVE_BPF
 #define HAVE_BSD_ROUTE_SOCKET
+#define __APPLE_USE_RFC_3542 1
 #endif
 
 #if defined(__FreeBSD__)
@@ -93,6 +102,13 @@ typedef unsigned short sa_family_t;
 #endif
 
 #if defined(__linux__)
+/*
+ * the following is not necessary on modern (2024) linux systems, but
+ * is necessary to get TH_SYN, and uh_sport for older still-supported
+ * linux systems.  keep it here for now.  note: we define TH_SYN below
+ * if TH_SYN is not defined, so the original reason for including this
+ * (according to CVS logs) is no longer true.
+ */
 #define __FAVOR_BSD
 #endif
 

--- a/lib/libscamperctrl/libscamperctrl.c
+++ b/lib/libscamperctrl/libscamperctrl.c
@@ -1,7 +1,7 @@
 /*
  * libscamperctrl
  *
- * $Id: libscamperctrl.c,v 1.57 2024/02/18 19:06:41 mjl Exp $
+ * $Id: libscamperctrl.c,v 1.59 2024/04/26 06:52:24 mjl Exp $
  *
  *        Matthew Luckie
  *        mjl@luckie.org.nz
@@ -285,7 +285,7 @@ static scamper_cmd_t *scamper_inst_cmd(scamper_inst_t *inst,
     }
   for(i=0; i<len; i++)
     {
-      if(isprint(str[i]) == 0)
+      if(isprint((unsigned char)str[i]) == 0)
 	{
 	  snprintf(inst->err, sizeof(inst->err),
 		   "unprintable character in command");
@@ -992,7 +992,7 @@ static int scamper_inst_read(scamper_inst_t *inst)
 	      if(start[3] == ' ' && start[4] != '\0')
 		{
 		  ptr = start + 4; i = 0;
-		  while(isprint(ptr[i]))
+		  while(isprint((unsigned char)ptr[i]))
 		    i++;
 		  if(ptr[i] == '\0')
 		    size = i;
@@ -1562,7 +1562,7 @@ scamper_attp_t *scamper_attp_alloc_dm(const char *file, const int line)
   if(attp == NULL) return NULL;
   memset(attp, 0, len);
   return attp;
-}  
+}
 
 #ifdef DMALLOC
 #undef scamper_attp_alloc
@@ -1586,7 +1586,7 @@ static int scamper_attp_str_isvalid(const char *str)
 
   for(i=0; str[i] != '\0'; i++)
     {
-      if(isprint(str[i]) == 0)
+      if(isprint((unsigned char)str[i]) == 0)
 	return 0;
       if(str[i] == '"')
 	return 0;
@@ -1622,7 +1622,7 @@ int scamper_attp_set_listdescr(scamper_attp_t *attp, char *list_descr)
     return -1;
   if(attp->l_descr != NULL)
     free(attp->l_descr);
-  attp->l_descr = tmp;  
+  attp->l_descr = tmp;
   return 0;
 }
 
@@ -1634,7 +1634,7 @@ int scamper_attp_set_listmonitor(scamper_attp_t *attp, char *list_monitor)
     return -1;
   if(attp->l_monitor != NULL)
     free(attp->l_monitor);
-  attp->l_monitor = tmp;  
+  attp->l_monitor = tmp;
   return 0;
 }
 

--- a/lib/python/cscamper_addr.pxd
+++ b/lib/python/cscamper_addr.pxd
@@ -24,6 +24,7 @@ cdef extern from "scamper_addr.h":
  void scamper_addr_free(scamper_addr_t *sa)
  scamper_addr_t *scamper_addr_use(scamper_addr_t *sa)
  scamper_addr_t *scamper_addr_fromstr(int kind, const char *addr)
+ scamper_addr_t *scamper_addr_alloc(int kind, const void *addr)
 
  const char *scamper_addr_tostr(const scamper_addr_t *sa,
 			        char *dst, const size_t size)

--- a/lib/python/cscamper_host.pxd
+++ b/lib/python/cscamper_host.pxd
@@ -41,6 +41,8 @@ cdef extern from "scamper_host.h":
   pass
  ctypedef struct scamper_host_rr_mx_t:
   pass
+ ctypedef struct scamper_host_rr_txt_t:
+  pass
 
  void scamper_host_free(scamper_host_t *host)
 
@@ -92,6 +94,7 @@ cdef extern from "scamper_host.h":
  const char *scamper_host_rr_str_get(const scamper_host_rr_t *rr)
  scamper_host_rr_soa_t *scamper_host_rr_soa_get(const scamper_host_rr_t *rr)
  scamper_host_rr_mx_t *scamper_host_rr_mx_get(const scamper_host_rr_t *rr)
+ scamper_host_rr_txt_t *scamper_host_rr_txt_get(const scamper_host_rr_t *rr)
 
  scamper_host_rr_mx_t *scamper_host_rr_mx_use(scamper_host_rr_mx_t *mx)
  void scamper_host_rr_mx_free(scamper_host_rr_mx_t *mx)
@@ -107,3 +110,8 @@ cdef extern from "scamper_host.h":
  uint32_t scamper_host_rr_soa_retry_get(const scamper_host_rr_soa_t *soa)
  uint32_t scamper_host_rr_soa_expire_get(const scamper_host_rr_soa_t *soa)
  uint32_t scamper_host_rr_soa_minimum_get(const scamper_host_rr_soa_t *soa)
+
+ scamper_host_rr_txt_t *scamper_host_rr_txt_use(scamper_host_rr_txt_t *txt)
+ void scamper_host_rr_txt_free(scamper_host_rr_txt_t *txt)
+ uint16_t scamper_host_rr_txt_strc_get(const scamper_host_rr_txt_t *txt)
+ const char *scamper_host_rr_txt_str_get(const scamper_host_rr_txt_t *txt, uint16_t i)

--- a/lib/python/cscamper_ping.pxd
+++ b/lib/python/cscamper_ping.pxd
@@ -117,6 +117,7 @@ cdef extern from "scamper_ping.h":
  scamper_ping_reply_v4rr_t *scamper_ping_reply_v4rr_get(const scamper_ping_reply_t *reply)
  scamper_ping_reply_v4ts_t *scamper_ping_reply_v4ts_get(const scamper_ping_reply_t *reply)
  scamper_ping_reply_tsreply_t *scamper_ping_reply_tsreply_get(const scamper_ping_reply_t *reply)
+ const char *scamper_ping_reply_ifname_get(const scamper_ping_reply_t *reply)
 
  void scamper_ping_reply_tsreply_free(scamper_ping_reply_tsreply_t *tsr)
  uint32_t scamper_ping_reply_tsreply_tso_get(const scamper_ping_reply_tsreply_t *tsr)

--- a/lib/python/cscamper_tbit.pxd
+++ b/lib/python/cscamper_tbit.pxd
@@ -2,7 +2,7 @@
 #
 # Author: Matthew Luckie
 #
-# Copyright (C) 2023 The Regents of the University of California
+# Copyright (C) 2023-2024 The Regents of the University of California
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,8 +17,55 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
+from libc.stdint cimport uint8_t, uint16_t, uint32_t
+from posix.time cimport timeval
+
+cdef extern from "scamper_addr.h":
+ ctypedef struct scamper_addr_t:
+  pass
+
+cdef extern from "scamper_list.h":
+ ctypedef struct scamper_list_t:
+  pass
+ ctypedef struct scamper_cycle_t:
+  pass
+
 cdef extern from "scamper_tbit.h":
  ctypedef struct scamper_tbit_t:
   pass
 
+ ctypedef struct scamper_tbit_pkt_t:
+  pass
+
  void scamper_tbit_free(scamper_tbit_t *tbit)
+ scamper_list_t *scamper_tbit_list_get(const scamper_tbit_t *tbit)
+ scamper_cycle_t *scamper_tbit_cycle_get(const scamper_tbit_t *tbit)
+ uint32_t scamper_tbit_userid_get(const scamper_tbit_t *tbit)
+ scamper_addr_t *scamper_tbit_src_get(const scamper_tbit_t *tbit)
+ scamper_addr_t *scamper_tbit_dst_get(const scamper_tbit_t *tbit)
+ uint16_t scamper_tbit_sport_get(const scamper_tbit_t *tbit)
+ uint16_t scamper_tbit_dport_get(const scamper_tbit_t *tbit)
+ const timeval *scamper_tbit_start_get(const scamper_tbit_t *tbit)
+ char *scamper_tbit_result_tostr(const scamper_tbit_t *tbit,char *buf,size_t len)
+ scamper_tbit_pkt_t *scamper_tbit_pkt_get(const scamper_tbit_t *tbit,uint32_t i)
+ uint32_t scamper_tbit_pktc_get(const scamper_tbit_t *tbit)
+ uint8_t scamper_tbit_type_get(const scamper_tbit_t *tbit)
+ uint8_t scamper_tbit_app_proto_get(const scamper_tbit_t *tbit)
+ uint32_t scamper_tbit_options_get(const scamper_tbit_t *tbit)
+ uint16_t scamper_tbit_client_mss_get(const scamper_tbit_t *tbit)
+ const uint8_t *scamper_tbit_client_fo_cookie_get(const scamper_tbit_t *tbit)
+ uint8_t scamper_tbit_client_fo_cookielen_get(const scamper_tbit_t *tbit)
+ uint8_t scamper_tbit_client_wscale_get(const scamper_tbit_t *tbit)
+ uint8_t scamper_tbit_client_ipttl_get(const scamper_tbit_t *tbit)
+ uint8_t scamper_tbit_client_syn_retx_get(const scamper_tbit_t *tbit)
+ uint8_t scamper_tbit_client_dat_retx_get(const scamper_tbit_t *tbit)
+ uint16_t scamper_tbit_server_mss_get(const scamper_tbit_t *tbit)
+ int scamper_tbit_server_fo_cookie_get(scamper_tbit_t *tbit,
+			               uint8_t *cookie, uint8_t *cookie_len)
+
+ scamper_tbit_pkt_t *scamper_tbit_pkt_use(scamper_tbit_pkt_t *pkt)
+ void scamper_tbit_pkt_free(scamper_tbit_pkt_t *pkt)
+ const timeval *scamper_tbit_pkt_tv_get(const scamper_tbit_pkt_t *pkt)
+ uint8_t scamper_tbit_pkt_dir_get(const scamper_tbit_pkt_t *pkt)
+ uint16_t scamper_tbit_pkt_len_get(const scamper_tbit_pkt_t *pkt)
+ const uint8_t *scamper_tbit_pkt_data_get(const scamper_tbit_pkt_t *pkt)

--- a/lib/python/cscamper_udpprobe.pxd
+++ b/lib/python/cscamper_udpprobe.pxd
@@ -2,7 +2,7 @@
 #
 # Author: Matthew Luckie
 #
-# Copyright (C) 2023 The Regents of the University of California
+# Copyright (C) 2023-2024 The Regents of the University of California
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -33,6 +33,8 @@ cdef extern from "scamper_list.h":
 cdef extern from "scamper_udpprobe.h":
  ctypedef struct scamper_udpprobe_t:
   pass
+ ctypedef struct scamper_udpprobe_probe_t:
+  pass
  ctypedef struct scamper_udpprobe_reply_t:
   pass
 
@@ -47,14 +49,24 @@ cdef extern from "scamper_udpprobe.h":
  uint16_t scamper_udpprobe_dport_get(const scamper_udpprobe_t *up)
  const timeval *scamper_udpprobe_start_get(const scamper_udpprobe_t *up)
  const timeval *scamper_udpprobe_wait_timeout_get(const scamper_udpprobe_t *up)
+ const timeval *scamper_udpprobe_wait_probe_get(const scamper_udpprobe_t *up)
  int scamper_udpprobe_flag_is_exitfirst(const scamper_udpprobe_t *up)
  const uint8_t *scamper_udpprobe_data_get(const scamper_udpprobe_t *up)
  uint16_t scamper_udpprobe_len_get(const scamper_udpprobe_t *up)
- scamper_udpprobe_reply_t *scamper_udpprobe_reply_get(const scamper_udpprobe_t *up, uint8_t i)
- uint8_t scamper_udpprobe_replyc_get(const scamper_udpprobe_t *up)
+ uint8_t scamper_udpprobe_probe_count_get(const scamper_udpprobe_t *up);
+ uint8_t scamper_udpprobe_probe_sent_get(const scamper_udpprobe_t *up);
+ uint8_t scamper_udpprobe_stop_count_get(const scamper_udpprobe_t *up);
+ scamper_udpprobe_probe_t *scamper_udpprobe_probe_get(const scamper_udpprobe_t *up, uint8_t i);
+
+ void scamper_udpprobe_probe_free(scamper_udpprobe_probe_t *probe);
+ scamper_udpprobe_probe_t *scamper_udpprobe_probe_use(scamper_udpprobe_probe_t *probe);
+ const timeval *scamper_udpprobe_probe_tx_get(const scamper_udpprobe_probe_t *probe);
+ uint16_t scamper_udpprobe_probe_sport_get(const scamper_udpprobe_probe_t *probe);
+ scamper_udpprobe_reply_t *scamper_udpprobe_probe_reply_get(const scamper_udpprobe_probe_t *probe, uint8_t i);
+ uint8_t scamper_udpprobe_probe_replyc_get(const scamper_udpprobe_probe_t *probe);
 
  void scamper_udpprobe_reply_free(scamper_udpprobe_reply_t *ur)
  scamper_udpprobe_reply_t *scamper_udpprobe_reply_use(scamper_udpprobe_reply_t *ur)
  const uint8_t *scamper_udpprobe_reply_data_get(const scamper_udpprobe_reply_t *ur)
  uint16_t scamper_udpprobe_reply_len_get(const scamper_udpprobe_reply_t *ur)
- const timeval *scamper_udpprobe_reply_tv_get(const scamper_udpprobe_reply_t *ur)
+ const timeval *scamper_udpprobe_reply_rx_get(const scamper_udpprobe_reply_t *ur)

--- a/lib/python/scamper.pyx
+++ b/lib/python/scamper.pyx
@@ -62,6 +62,8 @@ The scamper module supports the following measurements:
 :meth:`~scamper.ScamperCtrl.do_http`
 #. UDP probes (:class:`ScamperUdpprobe`) via \
 :meth:`~scamper.ScamperCtrl.do_udpprobe`
+#. TCP behavior inference (:class:`ScamperTbit`) via \
+:meth:`~scamper.ScamperCtrl.do_tbit`
 
 In order to request one of the scamper instances represented by a
 :class:`ScamperInst` object conducts a measurement, call the specific
@@ -359,11 +361,6 @@ class ScamperHostType(enum.IntEnum):
     NSEC = 47
     DNSKEY = 48
 
-SCAMPER_HOST_RR_DATA_TYPE_ADDR = 1
-SCAMPER_HOST_RR_DATA_TYPE_STR  = 2
-SCAMPER_HOST_RR_DATA_TYPE_SOA  = 3
-SCAMPER_HOST_RR_DATA_TYPE_MX   = 4
-
 # from scamper_sniff.h
 class ScamperSniffStop(enum.IntEnum):
     NoReason = 0
@@ -397,12 +394,25 @@ cdef class ScamperAddr:
     cdef cscamper_addr.scamper_addr_t *_c
 
     def __init__(self, addr):
-        cdef cscamper_addr.scamper_addr_t *c
-        if not isinstance(addr, str):
-            raise TypeError("expected string for addr")
-        c = cscamper_addr.scamper_addr_fromstr(0, addr.encode('UTF-8'))
+        cdef cscamper_addr.scamper_addr_t *c = NULL
+        cdef uint8_t buf[16]
+        cdef int at
+        if isinstance(addr, str):
+            c = cscamper_addr.scamper_addr_fromstr(0, addr.encode('UTF-8'))
+        elif isinstance(addr, bytes):
+            if len(addr) == 4:
+                at = 1
+            elif len(addr) == 16:
+                at = 2
+            elif len(addr) == 6:
+                at = 3
+            else:
+                raise ValueError("expected bytes array of 4/6/16 bytes")
+            for i, b in enumerate(addr):
+                buf[i] = b
+            c = cscamper_addr.scamper_addr_alloc(at, buf)
         if c == NULL:
-            raise ValueError("invalid address passed in string")
+            raise ValueError("invalid address")
         self._c = c
 
     def __str__(self):
@@ -435,15 +445,15 @@ cdef class ScamperAddr:
             return NotImplemented
         if op == Py_EQ:
             return x == 0
-        elif op == Py_NE:
+        if op == Py_NE:
             return x != 0
-        elif op == Py_LT:
+        if op == Py_LT:
             return x < 0
-        elif op == Py_LE:
+        if op == Py_LE:
             return x <= 0
-        elif op == Py_GT:
+        if op == Py_GT:
             return x > 0
-        elif op == Py_GE:
+        if op == Py_GE:
             return x >= 0
         return NotImplemented
 
@@ -573,35 +583,23 @@ cdef class ScamperList:
         if self._c != NULL:
             cscamper_list.scamper_list_free(self._c)
 
-    def __eq__(self, other):
+    def __richcmp__(self, other, int op):
         if not isinstance(other, ScamperList):
             return NotImplemented
-        return cscamper_list.scamper_list_cmp(self._c, (<ScamperList>other)._c) == 0
-
-    def __ne__(self, other):
-        if not isinstance(other, ScamperList):
-            return NotImplemented
-        return cscamper_list.scamper_list_cmp(self._c, (<ScamperList>other)._c) != 0
-
-    def __lt__(self, other):
-        if not isinstance(other, ScamperList):
-            return NotImplemented
-        return cscamper_list.scamper_list_cmp(self._c, (<ScamperList>other)._c) < 0
-
-    def __le__(self, other):
-        if not isinstance(other, ScamperList):
-            return NotImplemented
-        return cscamper_list.scamper_list_cmp(self._c, (<ScamperList>other)._c) <= 0
-
-    def __gt__(self, other):
-        if not isinstance(other, ScamperList):
-            return NotImplemented
-        return cscamper_list.scamper_list_cmp(self._c, (<ScamperList>other)._c) > 0
-
-    def __ge__(self, other):
-        if not isinstance(other, ScamperList):
-            return NotImplemented
-        return cscamper_list.scamper_list_cmp(self._c, (<ScamperList>other)._c) >= 0
+        x = cscamper_list.scamper_list_cmp(self._c, (<ScamperList>other)._c)
+        if op == Py_EQ:
+            return x == 0
+        if op == Py_NE:
+            return x != 0
+        if op == Py_LT:
+            return x < 0
+        if op == Py_LE:
+            return x <= 0
+        if op == Py_GT:
+            return x > 0
+        if op == Py_GE:
+            return x >= 0
+        return NotImplemented
 
     @staticmethod
     cdef ScamperList from_ptr(cscamper_list.scamper_list_t *ptr):
@@ -690,35 +688,23 @@ cdef class ScamperCycle:
         if self._c != NULL:
             cscamper_list.scamper_cycle_free(self._c)
 
-    def __eq__(self, other):
+    def __richcmp__(self, other, int op):
         if not isinstance(other, ScamperCycle):
             return NotImplemented
-        return cscamper_list.scamper_cycle_cmp(self._c, (<ScamperCycle>other)._c) == 0
-
-    def __ne__(self, other):
-        if not isinstance(other, ScamperCycle):
-            return NotImplemented
-        return cscamper_list.scamper_cycle_cmp(self._c, (<ScamperCycle>other)._c) != 0
-
-    def __lt__(self, other):
-        if not isinstance(other, ScamperCycle):
-            return NotImplemented
-        return cscamper_list.scamper_cycle_cmp(self._c, (<ScamperCycle>other)._c) < 0
-
-    def __le__(self, other):
-        if not isinstance(other, ScamperCycle):
-            return NotImplemented
-        return cscamper_list.scamper_cycle_cmp(self._c, (<ScamperCycle>other)._c) <= 0
-
-    def __gt__(self, other):
-        if not isinstance(other, ScamperCycle):
-            return NotImplemented
-        return cscamper_list.scamper_cycle_cmp(self._c, (<ScamperCycle>other)._c) > 0
-
-    def __ge__(self, other):
-        if not isinstance(other, ScamperCycle):
-            return NotImplemented
-        return cscamper_list.scamper_cycle_cmp(self._c, (<ScamperCycle>other)._c) >= 0
+        x = cscamper_list.scamper_cycle_cmp(self._c, (<ScamperCycle>other)._c)
+        if op == Py_EQ:
+            return x == 0
+        if op == Py_NE:
+            return x != 0
+        if op == Py_LT:
+            return x < 0
+        if op == Py_LE:
+            return x <= 0
+        if op == Py_GT:
+            return x > 0
+        if op == Py_GE:
+            return x >= 0
+        return NotImplemented
 
     @staticmethod
     cdef ScamperCycle from_ptr(cscamper_list.scamper_cycle_t *ptr, uint16_t t):
@@ -886,35 +872,23 @@ cdef class ScamperIcmpExt:
         if self._c != NULL:
             cscamper_icmpext.scamper_icmpext_free(self._c)
 
-    def __eq__(self, other):
+    def __richcmp__(self, other, int op):
         if not isinstance(other, ScamperIcmpExt):
             return NotImplemented
-        return cscamper_icmpext.scamper_icmpext_cmp(self._c, (<ScamperIcmpExt>other)._c) == 0
-
-    def __ne__(self, other):
-        if not isinstance(other, ScamperIcmpExt):
-            return NotImplemented
-        return cscamper_icmpext.scamper_icmpext_cmp(self._c, (<ScamperIcmpExt>other)._c) != 0
-
-    def __lt__(self, other):
-        if not isinstance(other, ScamperIcmpExt):
-            return NotImplemented
-        return cscamper_icmpext.scamper_icmpext_cmp(self._c, (<ScamperIcmpExt>other)._c) < 0
-
-    def __le__(self, other):
-        if not isinstance(other, ScamperIcmpExt):
-            return NotImplemented
-        return cscamper_icmpext.scamper_icmpext_cmp(self._c, (<ScamperIcmpExt>other)._c) <= 0
-
-    def __gt__(self, other):
-        if not isinstance(other, ScamperIcmpExt):
-            return NotImplemented
-        return cscamper_icmpext.scamper_icmpext_cmp(self._c, (<ScamperIcmpExt>other)._c) > 0
-
-    def __ge__(self, other):
-        if not isinstance(other, ScamperIcmpExt):
-            return NotImplemented
-        return cscamper_icmpext.scamper_icmpext_cmp(self._c, (<ScamperIcmpExt>other)._c) >= 0
+        x = cscamper_icmpext.scamper_icmpext_cmp(self._c, (<ScamperIcmpExt>other)._c)
+        if op == Py_EQ:
+            return x == 0
+        if op == Py_NE:
+            return x != 0
+        if op == Py_LT:
+            return x < 0
+        if op == Py_LE:
+            return x <= 0
+        if op == Py_GT:
+            return x > 0
+        if op == Py_GE:
+            return x >= 0
+        return NotImplemented
 
     @staticmethod
     cdef ScamperIcmpExt from_ptr(cscamper_icmpext.scamper_icmpext_t *ptr):
@@ -2122,6 +2096,27 @@ cdef class ScamperPingReply:
         return datetime.timedelta(seconds=c.tv_sec, microseconds=c.tv_usec)
 
     @property
+    def rx(self):
+        """
+        get method to obtain the receive time for this response, if
+        available.
+
+        :returns: the receive time
+        :rtype: datetime
+        """
+        txc = cscamper_ping.scamper_ping_reply_tx_get(self._c)
+        if txc == NULL:
+            return None
+        t = time.gmtime(txc.tv_sec)
+        rttc = cscamper_ping.scamper_ping_reply_rtt_get(self._c)
+
+        dt = datetime.datetime(t[0], t[1], t[2], t[3], t[4], t[5], txc.tv_usec,
+                               tzinfo=datetime.timezone.utc)
+        td = datetime.timedelta(seconds=rttc.tv_sec, microseconds=rttc.tv_usec)
+
+        return dt + td;
+
+    @property
     def attempt(self):
         """
         get method to obtain the attempt number for this probe.  The
@@ -2306,6 +2301,20 @@ cdef class ScamperPingReply:
         if not cscamper_ping.scamper_ping_reply_is_tcp(self._c):
             return None
         return cscamper_ping.scamper_ping_reply_tcp_flags_get(self._c)
+
+    @property
+    def ifname(self):
+        """
+        get method to obtain the name of the interface that received the
+        reply, if recorded.
+
+        :return: the name of the interface.
+        :rtype: string
+        """
+        c = cscamper_ping.scamper_ping_reply_ifname_get(self._c)
+        if c == NULL:
+            return None
+        return c.decode('UTF-8', 'strict')
 
 cdef class ScamperPing:
     """
@@ -3290,14 +3299,15 @@ cdef class ScamperTracelbLink:
 
     def __str__(self):
         cdef char buf[128]
+        out = []
 
         n = cscamper_tracelb.scamper_tracelb_link_from_get(self._c)
         a = cscamper_tracelb.scamper_tracelb_node_addr_get(n)
         if a != NULL:
             cscamper_addr.scamper_addr_tostr(a, buf, sizeof(buf))
-            out = buf.decode('UTF-8', 'strict')
+            out.append(buf.decode('UTF-8', 'strict'))
         else:
-            out = "*"
+            out.append("*")
 
         hopc = cscamper_tracelb.scamper_tracelb_link_hopc_get(self._c)
         for j in range(hopc-1):
@@ -3306,30 +3316,30 @@ cdef class ScamperTracelbLink:
             nullc = cscamper_tracelb.scamper_tracelb_probeset_summary_nullc_get(sm)
             addrc = cscamper_tracelb.scamper_tracelb_probeset_summary_addrc_get(sm)
             if nullc > 0 and addrc == 0:
-                out = out + " -> *"
+                out.append(" -> *")
             else:
-                out = out + "("
+                out.append("(")
                 for k in range(addrc):
                     if k > 0:
-                        out = out + ", "
+                        out.append(", ")
                     a = cscamper_tracelb.scamper_tracelb_probeset_summary_addr_get(sm, k)
                     cscamper_addr.scamper_addr_tostr(a, buf, sizeof(buf))
-                    out = out + buf.decode('UTF-8', 'strict')
+                    out.append(buf.decode('UTF-8', 'strict'))
                 if nullc > 0:
-                    out = out + ", *)"
+                    out.append(", *)")
                 else:
-                    out = out + ")"
+                    out.append(")")
             cscamper_tracelb.scamper_tracelb_probeset_summary_free(sm)
 
         n = cscamper_tracelb.scamper_tracelb_link_to_get(self._c)
         a = cscamper_tracelb.scamper_tracelb_node_addr_get(n)
         if a != NULL:
             cscamper_addr.scamper_addr_tostr(a, buf, sizeof(buf))
-            out = out + " -> " + buf.decode('UTF-8', 'strict')
+            out.append(" -> " + buf.decode('UTF-8', 'strict'))
         else:
-            out = out + " -> *"
+            out.append(" -> *")
 
-        return out
+        return ''.join(out)
 
     @staticmethod
     cdef ScamperTracelbLink from_ptr(cscamper_tracelb.scamper_tracelb_link_t *ptr):
@@ -3739,6 +3749,7 @@ cdef class ScamperDealiasReply:
     individual alias resolution probes.
     """
     cdef cscamper_dealias.scamper_dealias_reply_t *_c
+    cdef bint _fromdst
 
     def __init__(self):
         raise TypeError("This class cannot be insantiated directly.")
@@ -3748,13 +3759,24 @@ cdef class ScamperDealiasReply:
             cscamper_dealias.scamper_dealias_reply_free(self._c)
 
     @staticmethod
-    cdef ScamperDealiasReply from_ptr(cscamper_dealias.scamper_dealias_reply_t *ptr):
+    cdef ScamperDealiasReply from_ptr(cscamper_dealias.scamper_dealias_reply_t *ptr,
+                                      cscamper_dealias.scamper_dealias_probe_t *probe):
         cdef ScamperDealiasReply r
         if ptr == NULL:
             return None
         r = ScamperDealiasReply.__new__(ScamperDealiasReply)
         r._c = cscamper_dealias.scamper_dealias_reply_use(ptr)
+        r._fromdst = cscamper_dealias.scamper_dealias_reply_from_target(probe, ptr)
         return r
+
+    def is_from_target(self):
+        """
+        get method to determine if the reply came from the target.
+
+        :returns: True if the reply came from the target.
+        :rtype: bool
+        """
+        return self._fromdst
 
     @property
     def src(self):
@@ -4133,7 +4155,8 @@ cdef class ScamperDealiasProbedef:
             return None
         cscamper_dealias.scamper_dealias_probedef_method_tostr(self._c, buf,
                                                                sizeof(buf))
-        out = "-P " + buf.decode('UTF-8', 'strict')
+        out = []
+        out.append("-P " + buf.decode('UTF-8', 'strict'))
         ttl = cscamper_dealias.scamper_dealias_probedef_ttl_get(self._c)
         size = cscamper_dealias.scamper_dealias_probedef_size_get(self._c)
         udp = cscamper_dealias.scamper_dealias_probedef_udp_get(self._c)
@@ -4143,7 +4166,7 @@ cdef class ScamperDealiasProbedef:
         if icmp != NULL:
             csum = cscamper_dealias.scamper_dealias_probedef_icmp_csum_get(icmp)
             if csum != 0:
-                out += f" -c {csum}"
+                out.append(f"-c {csum}")
         if udp != NULL or tcp != NULL:
             if udp != NULL:
                 sport = cscamper_dealias.scamper_dealias_probedef_udp_sport_get(udp)
@@ -4152,17 +4175,17 @@ cdef class ScamperDealiasProbedef:
                 sport = cscamper_dealias.scamper_dealias_probedef_tcp_sport_get(tcp)
                 dport = cscamper_dealias.scamper_dealias_probedef_tcp_dport_get(tcp)
             if dport != 0:
-                out += f" -d {dport}"
+                out.append(f"-d {dport}")
             if sport != 0:
-                out += f" -F {sport}"
+                out.append(f"-F {sport}")
         if dst != NULL:
             cscamper_addr.scamper_addr_tostr(dst, buf, sizeof(buf))
-            out += " -i " + buf.decode('UTF-8', 'strict')
+            out.append("-i " + buf.decode('UTF-8', 'strict'))
         if size != 0:
-            out += f" -s {size}"
+            out.append(f"-s {size}")
         if ttl != 0:
-            out += f" -t {ttl}"
-        return out
+            out.append(f"-t {ttl}")
+        return ' '.join(out)
 
     def __repr__(self):
         cdef char buf[128]
@@ -4175,45 +4198,46 @@ cdef class ScamperDealiasProbedef:
         tcp = cscamper_dealias.scamper_dealias_probedef_tcp_get(self._c)
         src = cscamper_dealias.scamper_dealias_probedef_src_get(self._c)
         dst = cscamper_dealias.scamper_dealias_probedef_dst_get(self._c)
-
         cscamper_dealias.scamper_dealias_probedef_method_tostr(self._c, buf,
                                                                sizeof(buf))
-        out = "ScamperDealiasProbedef('" + buf.decode('UTF-8', 'strict') + "'"
+
+        out = []
+        out.append("ScamperDealiasProbedef('" + buf.decode('UTF-8', 'strict') + "'")
 
         if src != NULL:
             cscamper_addr.scamper_addr_tostr(src, buf, sizeof(buf))
-            out += ", src='" + buf.decode('UTF-8', 'strict') + "'"
+            out.append(", src='" + buf.decode('UTF-8', 'strict') + "'")
         if dst != NULL:
             cscamper_addr.scamper_addr_tostr(dst, buf, sizeof(buf))
-            out += ", dst='" + buf.decode('UTF-8', 'strict') + "'"
+            out.append(", dst='" + buf.decode('UTF-8', 'strict') + "'")
         if ttl != 0:
-            out += f", ttl={ttl}"
+            out.append(f", ttl={ttl}")
         if size != 0:
-            out += f", size={size}"
+            out.append(f", size={size}")
 
         if udp != NULL:
             sp = cscamper_dealias.scamper_dealias_probedef_udp_sport_get(udp)
             dp = cscamper_dealias.scamper_dealias_probedef_udp_dport_get(udp)
             if sp != 0:
-                out += f", sport={sp}"
+                out.append(f", sport={sp}")
             if dp != 0:
-                out += f", dport={dp}"
+                out.append(f", dport={dp}")
         elif tcp != NULL:
             sp = cscamper_dealias.scamper_dealias_probedef_tcp_sport_get(tcp)
             dp = cscamper_dealias.scamper_dealias_probedef_tcp_dport_get(tcp)
             if sp != 0:
-                out += f", sport={sp}"
+                out.append(f", sport={sp}")
             if dp != 0:
-                out += f", dport={dp}"
+                out.append(f", dport={dp}")
         elif icmp != NULL:
             icmpid = cscamper_dealias.scamper_dealias_probedef_icmp_id_get(icmp)
             csum = cscamper_dealias.scamper_dealias_probedef_icmp_csum_get(icmp)
             if icmpid != 0:
-                out += f", icmp_id={icmpid}"
+                out.append(f", icmp_id={icmpid}")
             if csum != 0:
-                out += f", icmp_sum={csum}"
-        out += ")"
-        return out
+                out.append(f", icmp_sum={csum}")
+        out.append(")")
+        return ''.join(out)
 
     @staticmethod
     cdef ScamperDealiasProbedef from_ptr(cscamper_dealias.scamper_dealias_probedef_t *ptr):
@@ -4441,7 +4465,7 @@ cdef class ScamperDealiasProbe:
         :rtype: ScamperDealiasReply
         """
         r = cscamper_dealias.scamper_dealias_probe_reply_get(self._c, i)
-        return ScamperDealiasReply.from_ptr(r)
+        return ScamperDealiasReply.from_ptr(r, self._c)
 
     @property
     def reply_count(self):
@@ -4978,8 +5002,83 @@ cdef class ScamperNeighbourdisc:
 #### Scamper Tbit Object
 ####
 
+cdef class ScamperTbitPkt:
+    """
+    :class:`ScamperTbitPkt` is used by scamper to store information about
+    a single packet captured in a :class:`ScamperTbit`.
+    """
+    cdef cscamper_tbit.scamper_tbit_pkt_t *_c
+
+    def __init__(self):
+        raise TypeError("This class cannot be instantiated directly.")
+
+    def __dealloc__(self):
+        if self._c != NULL:
+            cscamper_tbit.scamper_tbit_pkt_free(self._c)
+
+    @staticmethod
+    cdef ScamperTbitPkt from_ptr(cscamper_tbit.scamper_tbit_pkt_t *ptr):
+        cdef ScamperTbitPkt pkt = ScamperTbitPkt.__new__(ScamperTbitPkt)
+        pkt._c = cscamper_tbit.scamper_tbit_pkt_use(ptr)
+        return pkt
+
+    @property
+    def timestamp(self):
+        """
+        get method that returns the time when this packet was transmitted
+        or received.
+
+        :returns: the timestamp for this packet
+        :rtype: datetime
+        """
+        c = cscamper_tbit.scamper_tbit_pkt_tv_get(self._c)
+        if c == NULL:
+            return None
+        t = time.gmtime(c.tv_sec)
+        return datetime.datetime(t[0], t[1], t[2], t[3], t[4], t[5], c.tv_usec,
+                                 tzinfo=datetime.timezone.utc)
+
+    def is_tx(self):
+        """
+        get method that returns True if the packet was transmitted by the
+        tbit client.
+
+        :returns: True if the packet was transmitted
+        :rtype: bool
+        """
+        d = cscamper_tbit.scamper_tbit_pkt_dir_get(self._c)
+        return d == 1
+
+    def is_rx(self):
+        """
+        get method that returns True if the packet was received by the
+        tbit client.
+
+        :returns: True if the packet was received
+        :rtype: bool
+        """
+        d = cscamper_tbit.scamper_tbit_pkt_dir_get(self._c)
+        return d == 2
+
+    @property
+    def data(self):
+        """
+        get method to obtain the contents of the packet.
+
+        :returns: contents of the packet including IP header
+        :rtype: bytes
+        """
+        cdef uint16_t s
+        cdef const uint8_t *ptr
+        s = cscamper_tbit.scamper_tbit_pkt_len_get(self._c)
+        ptr = cscamper_tbit.scamper_tbit_pkt_data_get(self._c)
+        if s == 0 or ptr == NULL:
+            return None
+        return ptr[:s]
+
 cdef class ScamperTbit:
     cdef cscamper_tbit.scamper_tbit_t *_c
+    cdef uint32_t _i, _pktc
     cdef public ScamperInst _inst
 
     def __init__(self):
@@ -4989,10 +5088,25 @@ cdef class ScamperTbit:
         if self._c != NULL:
             cscamper_tbit.scamper_tbit_free(self._c)
 
+    def __len__(self):
+        return self._pktc
+
+    def __iter__(self):
+        self._i = 0
+        return self
+
+    def __next__(self):
+        if self._i >= self._pktc:
+            raise StopIteration
+        c = cscamper_tbit.scamper_tbit_pkt_get(self._c, self._i)
+        self._i = self._i + 1
+        return ScamperTbitPkt.from_ptr(c)
+
     @staticmethod
     cdef ScamperTbit from_ptr(cscamper_tbit.scamper_tbit_t *ptr):
         cdef ScamperTbit tbit = ScamperTbit.__new__(ScamperTbit)
         tbit._c = ptr
+        tbit._pktc = cscamper_tbit.scamper_tbit_pktc_get(ptr)
         return tbit
 
     @property
@@ -5005,6 +5119,127 @@ cdef class ScamperTbit:
         :rtype: ScamperInst
         """
         return self._inst
+
+    @property
+    def list(self):
+        """
+        get list associated with this measurement.
+
+        :returns: the list
+        :rtype: ScamperList
+        """
+        c = cscamper_tbit.scamper_tbit_list_get(self._c)
+        return ScamperList.from_ptr(c)
+
+    @property
+    def cycle(self):
+        """
+        get cycle associated with this measurement.
+
+        :returns: the cycle
+        :rtype: ScamperCycle
+        """
+        c = cscamper_tbit.scamper_tbit_cycle_get(self._c)
+        return ScamperCycle.from_ptr(c, SCAMPER_FILE_OBJ_CYCLE_DEF)
+
+    @property
+    def src(self):
+        """
+        get method to obtain the source address for a tbit measurement.
+
+        :returns: the source address
+        :rtype: ScamperAddr
+        """
+        c_a = cscamper_tbit.scamper_tbit_src_get(self._c)
+        return ScamperAddr.from_ptr(c_a)
+
+    @property
+    def dst(self):
+        """
+        get method to obtain the destination address for tbit measurement.
+
+        :returns: the destination address
+        :rtype: ScamperAddr
+        """
+        c_a = cscamper_tbit.scamper_tbit_dst_get(self._c)
+        return ScamperAddr.from_ptr(c_a)
+
+    @property
+    def userid(self):
+        """
+        get method to obtain the userid parameter.
+
+        :returns: the userid
+        :rtype: int
+        """
+        return cscamper_tbit.scamper_tbit_userid_get(self._c)
+
+    @property
+    def start(self):
+        """
+        get method to obtain the time this measurement started.
+
+        :returns: the start timestamp
+        :rtype: datetime
+        """
+        c = cscamper_tbit.scamper_tbit_start_get(self._c)
+        if c == NULL:
+            return None
+        t = time.gmtime(c.tv_sec)
+        return datetime.datetime(t[0], t[1], t[2], t[3], t[4], t[5], c.tv_usec,
+                                 tzinfo=datetime.timezone.utc)
+
+    @property
+    def result(self):
+        """
+        get method to obtain the result of this measurement.
+
+        :returns: the result:
+        :rtype: string
+        """
+        cdef char buf[128]
+        cscamper_tbit.scamper_tbit_result_tostr(self._c, buf, sizeof(buf))
+        return buf.decode('UTF-8', 'strict')
+
+    @property
+    def pkt_count(self):
+        """
+        get method to obtain the number of packets exchanged
+
+        :returns: the number of exchanged packets
+        :rtype: int
+        """
+        return cscamper_tbit.scamper_tbit_pktc_get(self._c)
+
+    @property
+    def client_mss(self):
+        """
+        get method to obtain the MSS advertised by the tbit client
+
+        :returns: the client's maximum segment size
+        :rtype: int
+        """
+        return cscamper_tbit.scamper_tbit_client_mss_get(self._c)
+
+    @property
+    def client_wscale(self):
+        """
+        get method to obtain the window scale advertised by the tbit client
+
+        :returns: the client's window scale value
+        :rtype: int
+        """
+        return cscamper_tbit.scamper_tbit_client_wscale_get(self._c)
+
+    @property
+    def client_ipttl(self):
+        """
+        get method to obtain the IP TTL value used by the tbit client
+
+        :returns: the client's IP TTL value
+        :rtype: int
+        """
+        return cscamper_tbit.scamper_tbit_client_ipttl_get(self._c)
 
 ####
 #### Scamper Sting Object
@@ -5443,6 +5678,66 @@ cdef class ScamperHostSOA:
         """
         return cscamper_host.scamper_host_rr_soa_minimum_get(self._c)
 
+cdef class ScamperHostTXT:
+    """
+    The :class:`ScamperHostTXT` object stores fields from the TXT resource
+    record.
+    """
+    cdef cscamper_host.scamper_host_rr_txt_t *_c
+    cdef uint16_t _i
+
+    def __init__(self):
+        raise TypeError("This class cannot be instantiated directly.")
+
+    def __dealloc__(self):
+        if self._c != NULL:
+            cscamper_host.scamper_host_rr_txt_free(self._c)
+
+    @staticmethod
+    cdef ScamperHostTXT from_ptr(cscamper_host.scamper_host_rr_txt_t *ptr):
+        cdef ScamperHostTXT txt
+        if ptr == NULL:
+            return None
+        txt = ScamperHostTXT.__new__(ScamperHostTXT)
+        txt._c = cscamper_host.scamper_host_rr_txt_use(ptr)
+        return txt
+
+    def __iter__(self):
+        self._i = 0
+        return self
+
+    def __next__(self):
+        strc = cscamper_host.scamper_host_rr_txt_strc_get(self._c)
+        while self._i < strc:
+            txt = cscamper_host.scamper_host_rr_txt_str_get(self._c, self._i)
+            self._i += 1
+            if txt != NULL:
+                return txt.decode('UTF-8', 'strict')
+        raise StopIteration
+
+    @property
+    def strc(self):
+        """
+        get method to obtain the number of strings in this TXT record.
+
+        :returns: the number of strings
+        :rtype: int
+        """
+        return cscamper_host.scamper_host_rr_txt_strc_get(self._c)
+
+    def str(self, i):
+        """
+        get method to obtain the number of strings in this TXT record.
+
+        :param int i: The string of interest
+        :returns: the string
+        :rtype: string
+        """
+        txt = cscamper_host.scamper_host_rr_txt_str_get(self._c, i)
+        if txt == NULL:
+            return None
+        return txt.decode('UTF-8', 'strict')
+
 cdef class ScamperHostRR:
     """
     The :class:`ScamperHostRR` object stores fields from a DNS resource record.
@@ -5470,20 +5765,20 @@ cdef class ScamperHostRR:
         cscamper_host.scamper_host_qclass_tostr(class_n, qclass, sizeof(qclass))
         cscamper_host.scamper_host_qtype_tostr(type_n, qtype, sizeof(qtype))
 
-        dt = cscamper_host.scamper_host_rr_data_type(class_n, type_n)
-        if dt == SCAMPER_HOST_RR_DATA_TYPE_ADDR:
-            sa = cscamper_host.scamper_host_rr_addr_get(self._c)
-            x = ScamperAddr.from_ptr(sa)
-        elif dt == SCAMPER_HOST_RR_DATA_TYPE_STR:
-            rrstr = cscamper_host.scamper_host_rr_str_get(self._c)
+        sa = cscamper_host.scamper_host_rr_addr_get(self._c)
+        rrstr = cscamper_host.scamper_host_rr_str_get(self._c)
+        mx = cscamper_host.scamper_host_rr_mx_get(self._c)
+        soa = cscamper_host.scamper_host_rr_soa_get(self._c)
+        txt = cscamper_host.scamper_host_rr_txt_get(self._c)
+        if sa != NULL:
+            x = str(ScamperAddr.from_ptr(sa))
+        elif rrstr != NULL:
             x = rrstr.decode('UTF-8', 'strict')
-        elif dt == SCAMPER_HOST_RR_DATA_TYPE_MX:
-            mx = cscamper_host.scamper_host_rr_mx_get(self._c)
+        elif mx != NULL:
             mx_pref = cscamper_host.scamper_host_rr_mx_preference_get(mx)
             mx_exch = cscamper_host.scamper_host_rr_mx_exchange_get(mx)
             x = "{} {}".format(mx_pref, mx_exch.decode('UTF-8', 'strict'))
-        elif dt == SCAMPER_HOST_RR_DATA_TYPE_SOA:
-            soa = cscamper_host.scamper_host_rr_soa_get(self._c)
+        elif soa != NULL:
             soa_mname = cscamper_host.scamper_host_rr_soa_mname_get(soa)
             soa_rname = cscamper_host.scamper_host_rr_soa_rname_get(soa)
             soa_serial = cscamper_host.scamper_host_rr_soa_serial_get(soa)
@@ -5491,11 +5786,22 @@ cdef class ScamperHostRR:
             soa_retry = cscamper_host.scamper_host_rr_soa_retry_get(soa)
             soa_expire = cscamper_host.scamper_host_rr_soa_expire_get(soa)
             soa_minimum = cscamper_host.scamper_host_rr_soa_minimum_get(soa)
-            x = "{} {} {} {} {} {} {}".format(soa_mname.decode('UTF-8', 'strict'),
-                                              soa_rname.decode('UTF-8', 'strict'),
+            x = "{} {} {} {} {} {} {}".format(soa_mname.decode('UTF-8',
+                                                               'strict'),
+                                              soa_rname.decode('UTF-8',
+                                                               'strict'),
                                               soa_serial, soa_refresh,
                                               soa_retry, soa_expire,
                                               soa_minimum)
+        elif txt != NULL:
+            txt_strc = cscamper_host.scamper_host_rr_txt_strc_get(txt)
+            x = ""
+            for i in range(txt_strc):
+                txt_str = cscamper_host.scamper_host_rr_txt_str_get(txt, i)
+                if txt_str != NULL:
+                    if x != "":
+                        x = x + " "
+                    x = x + "\"" + txt_str.decode('UTF-8', 'strict') + "\""
         else:
             x = "not implemented"
 
@@ -5636,12 +5942,23 @@ cdef class ScamperHostRR:
         soa = cscamper_host.scamper_host_rr_soa_get(self._c)
         return ScamperHostSOA.from_ptr(soa)
 
+    @property
+    def txt(self):
+        """
+        get method to obtain an object that contains the TXT record.
+
+        :returns: the TXT record
+        :rtype: ScamperHostTXT
+        """
+        txt = cscamper_host.scamper_host_rr_txt_get(self._c)
+        return ScamperHostTXT.from_ptr(txt)
+
 class _ScamperHostRRIterator:
     """
     The :class:`_ScamperHostRRIterator` class provides a convenient
     interface to iterate over a given section in a DNS response.
     """
-    def __init__(self, query, section):
+    def __init__(self, query, section, rrtypes):
         """
         Construct a _ScamperHostRRIterator object.
 
@@ -5653,6 +5970,8 @@ class _ScamperHostRRIterator:
         self._query = query
         self._section = section
         self._index = 0
+        self._count = 0
+        self._rrtypes = None
         if query is not None:
             if section == 0:
                 self._count = query.ancount
@@ -5660,23 +5979,45 @@ class _ScamperHostRRIterator:
                 self._count = query.nscount
             else:
                 self._count = query.arcount
-        else:
-            self._count = 0
+        if rrtypes is not None:
+            self._rrtypes = {}
+            for rrtype in rrtypes:
+                if not isinstance(rrtype, str):
+                    raise ValueError("expected str in rrtypes")
+                rrtl = rrtype.lower()
+                if rrtl == 'a':
+                    self._rrtypes[1] = 1
+                elif rrtl == 'aaaa':
+                    self._rrtypes[28] = 1
+                elif rrtl == 'ptr':
+                    self._rrtypes[12] = 1
+                elif rrtl == 'mx':
+                    self._rrtypes[15] = 1
+                elif rrtl == 'ns':
+                    self._rrtypes[2] = 1
+                elif rrtl == 'soa':
+                    self._rrtypes[6] = 1
+                elif rrtl == 'txt':
+                    self._rrtypes[16] = 1
+                else:
+                    raise ValueError(f"cannot filter {rrtype}")
 
     def __iter__(self):
         return self
 
     def __next__(self):
-        if self._index >= self._count:
-            raise StopIteration
-        if self._section == 0:
-            rr = self._query.an(self._index)
-        elif self._section == 1:
-            rr = self._query.ns(self._index)
-        else:
-            rr = self._query.ar(self._index)
-        self._index += 1
-        return rr
+        while self._index < self._count:
+            if self._section == 0:
+                rr = self._query.an(self._index)
+            elif self._section == 1:
+                rr = self._query.ns(self._index)
+            else:
+                rr = self._query.ar(self._index)
+            self._index += 1
+            if (self._rrtypes is None or
+                (rr.rclass == 1 and rr.rtype in self._rrtypes)):
+                return rr
+        raise StopIteration
 
 cdef class ScamperHostQuery:
     """
@@ -5729,6 +6070,21 @@ cdef class ScamperHostQuery:
         t = time.gmtime(c.tv_sec)
         return datetime.datetime(t[0], t[1], t[2], t[3], t[4], t[5], c.tv_usec,
                                  tzinfo=datetime.timezone.utc)
+
+    @property
+    def rtt(self):
+        """
+        get method that returns the the delay between query and response
+        for the query
+
+        :returns: the delay between query and response
+        :rtype: timedelta
+        """
+        tx = self.tx
+        rx = self.rx
+        if tx is None or rx is None:
+            return None
+        return rx - tx
 
     @property
     def rcode(self):
@@ -5992,6 +6348,45 @@ cdef class ScamperHost:
         return self._q.rcode
 
     @property
+    def tx(self):
+        """
+        get method to obtain the transmit time for the first query with
+        a response
+
+        :returns: the transmit timestamp
+        :rtype: datetime
+        """
+        if self._q is None:
+            return None
+        return self._q.tx
+
+    @property
+    def rx(self):
+        """
+        get method to obtain the receive time for the first query with
+        a response
+
+        :returns: the receive timestamp
+        :rtype: datetime
+        """
+        if self._q is None:
+            return None
+        return self._q.rx
+
+    @property
+    def rtt(self):
+        """
+        get method to obtain the delay between query and response for the
+        first query with a response
+
+        :returns: the delay between query and response
+        :rtype: timedelta
+        """
+        if self._q is None:
+            return None
+        return self._q.rtt
+
+    @property
     def ancount(self):
         """
         get method to obtain the number of AN RRs from the first query
@@ -6017,7 +6412,7 @@ cdef class ScamperHost:
             return None
         return self._q.an(i)
 
-    def ans(self):
+    def ans(self, rrtypes=None):
         """
         get method to obtain a RR Iterator over the AN section of the first
         query with a response
@@ -6025,7 +6420,7 @@ cdef class ScamperHost:
         :returns: an iterator
         :rtype: _ScamperHostRRIterator
         """
-        return _ScamperHostRRIterator(self._q, 0)
+        return _ScamperHostRRIterator(self._q, 0, rrtypes)
 
     @property
     def nscount(self):
@@ -6053,7 +6448,7 @@ cdef class ScamperHost:
             return None
         return self._q.ns(i)
 
-    def nss(self):
+    def nss(self, rrtypes=None):
         """
         get method to obtain a RR Iterator over the NS section of the first
         query with a response
@@ -6061,7 +6456,7 @@ cdef class ScamperHost:
         :returns: an iterator
         :rtype: _ScamperHostRRIterator
         """
-        return _ScamperHostRRIterator(self._q, 1)
+        return _ScamperHostRRIterator(self._q, 1, rrtypes)
 
     @property
     def arcount(self):
@@ -6089,7 +6484,7 @@ cdef class ScamperHost:
             return None
         return self._q.ar(i)
 
-    def ars(self):
+    def ars(self, rrtypes=None):
         """
         get method to obtain a RR Iterator over the AR section of the first
         query with a response
@@ -6097,7 +6492,7 @@ cdef class ScamperHost:
         :returns: an iterator
         :rtype: _ScamperHostRRIterator
         """
-        return _ScamperHostRRIterator(self._q, 2)
+        return _ScamperHostRRIterator(self._q, 2, rrtypes=None)
 
     def ans_addrs(self):
         """
@@ -6111,6 +6506,32 @@ cdef class ScamperHost:
             if rec.addr is not None:
                 addrs[rec.addr] = 1
         return list(addrs.keys())
+
+    def ans_nses(self):
+        """
+        get method to obtain all unique nameservers returned
+
+        :returns: a list of :str:
+        :rtype: a list of :str:
+        """
+        nses = {}
+        for rec in self.ans():
+            if rec.ns is not None:
+                nses[rec.ns] = 1
+        return list(nses.keys())
+
+    def ans_txts(self):
+        """
+        get method to obtain all txt records returned
+
+        :returns: a list of TXT RRs
+        :rtype: a list of :ScamperHostRR:
+        """
+        txts = []
+        for rec in self.ans():
+            if rec.txt is not None:
+                txts.append(rec)
+        return txts
 
 ####
 #### Scamper HTTP Object
@@ -6567,6 +6988,27 @@ cdef class ScamperHttp:
 ####
 #### Scamper Udpprobe Object
 ####
+class _ScamperUdpprobeReplyIterator:
+    def __init__(self, up):
+        self._up = up
+        self._pi = 0
+        self._pc = up.probe_sent
+        self._ri = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        while self._pi < self._pc:
+            probe = self._up.probe(self._pi)
+            while self._ri < probe.reply_count:
+                reply = probe.reply(self._ri)
+                self._ri += 1
+                return reply
+            self._pi += 1
+            self._ri = 0
+        raise StopIteration
+
 cdef class ScamperUdpprobeReply:
     """
     :class:`ScamperUdpprobeReply` is used by scamper to store responses
@@ -6595,7 +7037,7 @@ cdef class ScamperUdpprobeReply:
         :returns: the timestamp for the reply
         :rtype: datetime
         """
-        c = cscamper_udpprobe.scamper_udpprobe_reply_tv_get(self._c)
+        c = cscamper_udpprobe.scamper_udpprobe_reply_rx_get(self._c)
         if c == NULL:
             return None
         t = time.gmtime(c.tv_sec)
@@ -6618,6 +7060,86 @@ cdef class ScamperUdpprobeReply:
             return None
         return buf[:s]
 
+cdef class ScamperUdpprobeProbe:
+    """
+    :class:`ScamperUdpprobeProbe` is used by scamper to store information
+    about a specific UDP probe.
+    """
+    cdef cscamper_udpprobe.scamper_udpprobe_probe_t *_c
+    cdef uint8_t _i, _probe_sent
+
+    def __init__(self):
+        raise TypeError("This class cannot be instantiated directly.")
+
+    def __dealloc__(self):
+        if self._c != NULL:
+            cscamper_udpprobe.scamper_udpprobe_probe_free(self._c)
+
+    @staticmethod
+    cdef ScamperUdpprobeProbe from_ptr(cscamper_udpprobe.scamper_udpprobe_probe_t *ptr):
+        cdef ScamperUdpprobeProbe pr = ScamperUdpprobeProbe.__new__(ScamperUdpprobeProbe)
+        pr._c = cscamper_udpprobe.scamper_udpprobe_probe_use(ptr);
+        return pr
+
+    def __iter__(self):
+        self._i = 0
+        self._replyc = cscamper_udpprobe.scamper_udpprobe_probe_replyc_get(self._c)
+        return self
+
+    def __next__(self):
+        while self._i < self._replyc:
+            reply = cscamper_udpprobe.scamper_udpprobe_probe_reply_get(self._c, self._i)
+            self._i += 1
+            if reply != NULL:
+                return ScamperUdpprobeReply.from_ptr(reply)
+        raise StopIteration
+
+    @property
+    def tx(self):
+        """
+        get method that returns the time when the probe was transmitted.
+
+        :returns: the timestamp for the probe
+        :rtype: datetime
+        """
+        c = cscamper_udpprobe.scamper_udpprobe_probe_tx_get(self._c)
+        if c == NULL:
+            return None
+        t = time.gmtime(c.tv_sec)
+        return datetime.datetime(t[0], t[1], t[2], t[3], t[4], t[5], c.tv_usec,
+                                 tzinfo=datetime.timezone.utc)
+
+    @property
+    def sport(self):
+        """
+        get method to obtain the source port value used by this probe
+
+        :returns: the source port
+        :rtype: int
+        """
+        return cscamper_udpprobe.scamper_udpprobe_probe_sport_get(self._c)
+
+    @property
+    def reply_count(self):
+        """
+        get method that returns the number of replies recorded for this probe
+
+        :returns: the number of replies recorded
+        :rtype: int
+        """
+        return cscamper_udpprobe.scamper_udpprobe_probe_replyc_get(self._c)
+
+    def reply(self, i):
+        """
+        reply(i)
+        get method to obtain a reply for a specific attempt, starting at zero.
+
+        :returns: the nominated reply
+        :rtype: ScamperUdpprobeReply
+        """
+        c = cscamper_udpprobe.scamper_udpprobe_probe_reply_get(self._c, i)
+        return ScamperUdpprobeReply.from_ptr(c)
+
 cdef class ScamperUdpprobe:
     """
     :class:`ScamperUdpprobe` is used by scamper to store results from a UDP
@@ -6625,7 +7147,7 @@ cdef class ScamperUdpprobe:
     """
     cdef cscamper_udpprobe.scamper_udpprobe_t *_c
     cdef public ScamperInst _inst
-    cdef uint8_t _i, _replyc
+    cdef uint8_t _i, _probe_sent
 
     def __init__(self):
         raise TypeError("This class cannot be instantiated directly.")
@@ -6636,15 +7158,15 @@ cdef class ScamperUdpprobe:
 
     def __iter__(self):
         self._i = 0
-        self._replyc = cscamper_udpprobe.scamper_udpprobe_replyc_get(self._c)
+        self._probe_sent = cscamper_udpprobe.scamper_udpprobe_probe_sent_get(self._c)
         return self
 
     def __next__(self):
-        while self._i < self._replyc:
-            ur = cscamper_udpprobe.scamper_udpprobe_reply_get(self._c, self._i)
+        while self._i < self._probe_sent:
+            probe = cscamper_udpprobe.scamper_udpprobe_probe_get(self._c, self._i)
             self._i += 1
-            if ur != NULL: #iterate to the next buf
-                return ScamperUdpprobeReply.from_ptr(ur)
+            if probe != NULL:
+                return ScamperUdpprobeProbe.from_ptr(probe)
         raise StopIteration
 
     @staticmethod
@@ -6736,7 +7258,8 @@ cdef class ScamperUdpprobe:
     @property
     def sport(self):
         """
-        get method to obtain the source port the client used.
+        get method to obtain the source port value provided to the udpprobe
+        measurement.
 
         :returns: the source port
         :rtype: int
@@ -6784,8 +7307,25 @@ cdef class ScamperUdpprobe:
         return buf[:s]
 
     @property
-    def replyc(self):
-        return cscamper_udpprobe.scamper_udpprobe_replyc_get(self._c)
+    def probe_sent(self):
+        return cscamper_udpprobe.scamper_udpprobe_probe_sent_get(self._c)
+
+    def probe(self, i):
+        """
+        get method that returns a specific probe
+
+        :returns: the probe identified
+        :rtype: ScamperUdpprobeProbe
+        """
+        c = cscamper_udpprobe.scamper_udpprobe_probe_get(self._c, i)
+        return ScamperUdpprobeProbe.from_ptr(c)
+
+    def replies(self):
+        """
+        get an Iterator that contains the replies obtained during the
+        measurement.
+        """
+        return _ScamperUdpprobeReplyIterator(self)
 
 ####
 #### Scamper File Object
@@ -7200,15 +7740,18 @@ cdef void _ctrl_cb(clibscamperctrl.scamper_inst_t *c_inst,
                 ctrl._exceptions.append(e)
 
     elif cb_type == SCAMPER_CTRL_TYPE_ERR:
-        if data != NULL:
-            errstr = <const char *>data
-            ctrl._exceptions.append(ScamperInstError(
-                errstr.decode('UTF-8', 'strict'), inst))
-        else:
-            ctrl._exceptions.append(ScamperInstError("got err", inst))
+        errstr = <const char *>data
+        excstr = f"got err from {inst.name}"
+        if errstr != NULL and errstr[0] != ord('\0'):
+            excstr += ": " + errstr.decode('UTF-8', 'strict')
+        ctrl._exceptions.append(ScamperInstError(excstr, inst))
 
     elif cb_type == SCAMPER_CTRL_TYPE_FATAL:
-        ctrl._exceptions.append(RuntimeError("got fatal"))
+        excstr = f"got fatal from {inst.name}"
+        errstr = clibscamperctrl.scamper_ctrl_strerror(c_ctrl)
+        if errstr != NULL and errstr[0] != ord('\0'):
+            excstr += ": " + errstr.decode('UTF-8', 'strict')
+        ctrl._exceptions.append(ScamperInstError(excstr, inst))
 
     elif cb_type == SCAMPER_CTRL_TYPE_EOF:
         # got an eof on an instance.  remove the references to the tasks
@@ -7248,7 +7791,7 @@ cdef class ScamperCtrl:
     results.  This can save the caller from doing that itself.
     - unix: the path to a unix domain socket representing a local instance, \
     which will then become a :class:`ScamperInst`.
-    - remote_unix: the path to a unix domain socket representing a remote \
+    - remote: the path to a unix domain socket representing a remote \
     instance, which will then become a :class:`ScamperInst`.
     - remote_dir: the path to a directory containing unix domain sockets \
     each representing a remote instance, which will each then become a \
@@ -7300,14 +7843,18 @@ cdef class ScamperCtrl:
 
     def __dealloc__(self):
         # cython does not seem to empty lists on dealloc, so explicitly empty
-        while len(self._insts) > 0:
-            self._insts.pop(0)
-        while len(self._objs) > 0:
-            self._objs.pop(0)
-        while len(self._exceptions) > 0:
-            self._exceptions.pop(0)
-        while len(self._tasks) > 0:
-            self._tasks.pop(0)
+        if self._insts is not None:
+            while len(self._insts) > 0:
+                self._insts.pop(0)
+        if self._objs is not None:
+            while len(self._objs) > 0:
+                self._objs.pop(0)
+        if self._exceptions is not None:
+            while len(self._exceptions) > 0:
+                self._exceptions.pop(0)
+        if self._tasks is not None:
+            while len(self._tasks) > 0:
+                self._tasks.pop(0)
 
         # free the control structure
         if self._c != NULL:
@@ -7613,7 +8160,7 @@ cdef class ScamperCtrl:
         """
         do(cmd, inst=None, sync=False)
         sends a manually-constructed command using scamper syntax to the scamper
-        instance.  you should use one of the do_trace/do_ping/do_host functions
+        instance.  you should use one of the do_trace/do_ping/do_dns functions
         instead.
 
         :param string cmd: the command to send.
@@ -7691,7 +8238,8 @@ cdef class ScamperCtrl:
         :rtype: ScamperTask
         """
 
-        cmd = "trace"
+        args = []
+        args.append("trace")
         inst = self._getinst(inst)
 
         if method is not None:
@@ -7712,51 +8260,52 @@ cdef class ScamperCtrl:
                 raise ValueError("cannot specify ICMP parameters with " + method)
 
         if confidence is not None:
-            cmd = cmd + " -C " + str(confidence)
+            args.append(f"-C {confidence}")
         if dport is not None:
-            cmd = cmd + " -d " + str(dport)
+            args.append(f"-d {dport}")
         if firsthop is not None:
-            cmd = cmd + " -f " + str(firsthop)
+            args.append(f"-f {firsthop}")
         if gaplimit is not None:
-            cmd = cmd + " -g " + str(gaplimit)
+            args.append(f"-g {gaplimit}")
         if loops is not None:
-            cmd = cmd = " -l " + str(loops)
+            args.append(f"-l {loops}")
         if hoplimit is not None:
-            cmd = cmd + " -m " + str(hoplimit)
+            args.append(f"-m {hoplimit}")
         if pmtud is not None and pmtud is True:
-            cmd = cmd + " -M"
+            args.append("-M")
         if squeries is not None:
-            cmd = cmd + " -N " + str(squeries)
+            args.append(f"-N {squeries}")
         if ptr is not None and ptr is True:
-            cmd = cmd + " -O ptr"
+            args.append("-O ptr")
         if payload is not None:
-            cmd = cmd + " -p " + binascii.hexlify(payload).decode('ascii')
+            args.append(f"-p {binascii.hexlify(payload).decode('ascii')}")
         if method is not None:
-            cmd = cmd + " -P " + method
+            args.append(f"-P {method}")
         if attempts is not None:
-            cmd = cmd + " -q " + str(attempts)
+            args.append(f"-q {attempts}")
         if all_attempts is not None and all_attempts is True:
-            cmd = cmd + " -Q"
+            args.append("-Q")
         if rtr is not None:
-            cmd = cmd + " -r " + rtr
+            args.append(f"-r {rtr}")
         if sport is not None:
-            cmd = cmd + " -s " + str(sport)
+            args.append(f"-s {sport}")
         if src is not None:
-            cmd = cmd + " -S " + src
+            args.append(f"-S {src}")
         if tos is not None:
-            cmd = cmd + " -t " + str(tos)
+            args.append(f"-t {tos}")
         if userid is not None:
-            cmd = cmd + " -U " + str(userid)
+            args.append(f"-U {userid}")
         if wait_timeout is not None:
             if not isinstance(wait_timeout, datetime.timedelta):
                 wait_timeout = datetime.timedelta(seconds=wait_timeout)
-            cmd += f" -w {wait_timeout.total_seconds()}s"
+            args.append(f"-w {wait_timeout.total_seconds()}s")
         if wait_probe is not None:
             if not isinstance(wait_probe, datetime.timedelta):
                 wait_probe = datetime.timedelta(seconds=wait_probe)
-            cmd += f" -W {wait_probe.total_seconds()}s"
-        cmd = cmd + " " + str(dst)
+            args.append(f"-W {wait_probe.total_seconds()}s")
+        args.append(f"{dst}")
 
+        cmd = ' '.join(args)
         c = clibscamperctrl.scamper_inst_do((<ScamperInst>inst)._c,
                                             cmd.encode('UTF-8'), NULL)
         if c == NULL:
@@ -7807,7 +8356,8 @@ cdef class ScamperCtrl:
         :rtype: ScamperTask
         """
 
-        cmd = "tracelb"
+        args = []
+        args.append("tracelb")
         inst = self._getinst(inst)
 
         if method is not None:
@@ -7822,37 +8372,38 @@ cdef class ScamperCtrl:
                 raise ValueError("cannot specify source or destination ports with " + method)
 
         if confidence is not None:
-            cmd = cmd + " -c " + str(confidence)
+            args.append(f"-c {confidence}")
         if dport is not None:
-            cmd = cmd + " -d " + str(dport)
+            args.append(f"-d {dport}")
         if firsthop is not None:
-            cmd = cmd + " -f " + str(firsthop)
+            args.append(f"-f {firsthop}")
         if gaplimit is not None:
-            cmd = cmd + " -g " + str(gaplimit)
+            args.append(f"-g {gaplimit}")
         if method is not None:
-            cmd = cmd + " -P " + method
+            args.append(f"-P {method}")
         if attempts is not None:
-            cmd = cmd + " -q " + str(attempts)
+            args.append(f"-q {attempts}")
         if ptr is not None and ptr is True:
-            cmd = cmd + " -O ptr"
+            args.append("-O ptr")
         if rtr is not None:
-            cmd = cmd + " -r " + rtr
+            args.append(f"-r {rtr}")
         if sport is not None:
-            cmd = cmd + " -s " + str(sport)
+            args.append(f"-s {sport}")
         if tos is not None:
-            cmd = cmd + " -t " + str(tos)
+            args.append(f"-t {tos}")
         if userid is not None:
-            cmd = cmd + " -U " + str(userid)
+            args.append(f"-U {userid}")
         if wait_timeout is not None:
             if not isinstance(wait_timeout, datetime.timedelta):
                 wait_timeout = datetime.timedelta(seconds=wait_timeout)
-            cmd += f" -w {wait_timeout.total_seconds()}s"
+            args.append(f"-w {wait_timeout.total_seconds()}s")
         if wait_probe is not None:
             if not isinstance(wait_probe, datetime.timedelta):
                 wait_probe = datetime.timedelta(seconds=wait_probe)
-            cmd += f" -W {wait_probe.total_seconds()}s"
-        cmd = cmd + " " + str(dst)
+            args.append(f"-W {wait_probe.total_seconds()}s")
+        args.append(f"{dst}")
 
+        cmd = ' '.join(args)
         c = clibscamperctrl.scamper_inst_do((<ScamperInst>inst)._c,
                                             cmd.encode('UTF-8'), NULL)
         if c == NULL:
@@ -7918,7 +8469,8 @@ cdef class ScamperCtrl:
         :rtype: ScamperTask
         """
 
-        cmd = "ping"
+        args = []
+        args.append("ping")
         inst = self._getinst(inst)
 
         if dst is None:
@@ -7958,64 +8510,67 @@ cdef class ScamperCtrl:
                 raise ValueError("cannot specify source or destination ports with " + method)
 
         if tcp_ack is not None:
-            cmd = cmd + " -A " + str(tcp_ack)
+            args.append(f"-A {tcp_ack}")
         if tcp_seq is not None:
-            cmd = cmd + " -A " + str(tcp_seq)
+            args.append(f"-A {tcp_seq}")
         if payload is not None:
-            cmd = cmd + " -B " + binascii.hexlify(payload).decode('ascii')
+            args.append(f"-B {binascii.hexlify(payload).decode('ascii')}")
         if attempts is not None:
-            cmd = cmd + " -c " + str(attempts)
+            args.append(f"-c {attempts}")
         if icmp_sum is not None:
-            cmd = cmd + " -C " + str(icmp_sum)
+            args.append(f"-C {icmp_sum}")
         if dport is not None:
-            cmd = cmd + " -d " + str(dport)
+            args.append(f"-d {dport}")
         if icmp_seq is not None:
-            cmd = cmd + " -d " + str(icmp_seq)
+            args.append(f"-d {icmp_seq}")
         if sport is not None:
-            cmd = cmd + " -F " + str(sport)
+            args.append(f"-F {sport}")
         if icmp_id is not None:
-            cmd = cmd + " -F " + str(icmp_id)
+            args.append(f"-F {icmp_id}")
         if wait_probe is not None:
             if not isinstance(wait_probe, datetime.timedelta):
                 wait_probe = datetime.timedelta(seconds=wait_probe)
-            cmd += f" -i {wait_probe.total_seconds()}s"
+            args.append(f"-i {wait_probe.total_seconds()}s")
         if ttl is not None:
-            cmd = cmd + " -m " + str(ttl)
+            args.append(f"-m {ttl}")
         if mtu is not None:
-            cmd = cmd + " -M " + str(mtu)
+            args.append(f"-M {mtu}")
         if stop_count is not None:
-            cmd = cmd + " -o " + str(stop_count)
+            args.append(f"-o {stop_count}")
         if method is not None:
-            cmd = cmd + " -P " + method
+            args.append(f"-P {method}")
         if rtr is not None:
-            cmd = cmd + " -r " + rtr
+            args.append(f"-r {rtr}")
         if recordroute is not None and recordroute:
-            cmd = cmd + " -R "
+            args.append("-R")
         if size is not None:
-            cmd = cmd + " -s " + str(size)
+            args.append(f"-s {size}")
         if src is not None:
-            cmd = cmd + " -S " + src
+            args.append(f"-S {src}")
         if userid is not None:
-            cmd = cmd + " -U " + str(userid)
+            args.append(f"-U {userid}")
         if wait_timeout is not None:
             if not isinstance(wait_timeout, datetime.timedelta):
                 wait_timeout = datetime.timedelta(seconds=wait_timeout)
-            cmd += f" -W {wait_timeout.total_seconds()}s"
+            args.append(f"-W {wait_timeout.total_seconds()}s")
         if tos is not None:
-            cmd = cmd + " -z " + str(tos)
-        cmd = cmd + " " + str(dst)
+            args.append(f"-z {tos}")
+        args.append(f"{dst}")
 
+        cmd = ' '.join(args)
         c = clibscamperctrl.scamper_inst_do((<ScamperInst>inst)._c,
                                             cmd.encode('UTF-8'), NULL)
         if c == NULL:
             raise RuntimeError("could not schedule command")
         return self._task(c, (<ScamperInst>inst)._c, sync)
 
-    def do_dns(self, qname, server=None, qtype=None, attempts=None, rd=None,
-               wait_timeout=None, userid=None, inst=None, sync=False):
+    def do_dns(self, qname, server=None, qclass=None, qtype=None,
+               attempts=None, rd=None, wait_timeout=None, tcp=None,
+               userid=None, inst=None, sync=False):
         """
-        do_dns(qname, server=None, qtype=None, attempts=None, rd=None,\
-               wait_timeout=None, userid=None, inst=None, sync=False)
+        do_dns(qname, server=None, qclass=None, qtype=None,
+               attempts=None, rd=None, wait_timeout=None, tcp=None,
+               userid=None, inst=None, sync=False)
         conduct a DNS measurement guided by the assembled parameters.
         Only the qname is required; scamper will use built-in defaults
         for the other optional parameters if they are not provided.
@@ -8027,9 +8582,11 @@ cdef class ScamperCtrl:
         :param string qname: The name to query
         :param ScamperInst inst: The specific instance to issue command over
         :param string server: The DNS server to use
+        :param string qclass: The query class to use
         :param string qtype: The query type to use
         :param int attempts: The number of queries to make before giving up
         :param timedelta wait_timeout: The length of time to wait for a response
+        :param bool tcp: Use TCP instead of UDP for queries
         :param int userid: The userid value to tag with the DNS measurement
         :param bool rd: The recursion desired value to use
         :param bool sync: operate the measurement synchronously
@@ -8038,28 +8595,34 @@ cdef class ScamperCtrl:
         :rtype: ScamperTask or the completed measurement if sync=True
         """
 
-        cmd = "host"
+        args = []
+        args.append("host")
         inst = self._getinst(inst)
 
         if attempts is not None and attempts < 1:
             raise ValueError("attempts < 1")
 
         if server is not None:
-            cmd = cmd + " -s " + str(server)
+            args.append(f"-s {server}")
+        if qclass is not None:
+            args.append(f"-c {qclass}")
         if qtype is not None:
-            cmd = cmd + " -t " + qtype
+            args.append(f"-t {qtype}")
         if attempts is not None:
-            cmd = cmd + " -R " + str(attempts)
+            args.append(f"-R {attempts}")
         if wait_timeout is not None:
             if not isinstance(wait_timeout, datetime.timedelta):
                 wait_timeout = datetime.timedelta(seconds=wait_timeout)
-            cmd += f" -W {wait_timeout.total_seconds()}s"
+            args.append(f"-W {wait_timeout.total_seconds()}s")
         if userid is not None:
-            cmd = cmd + " -U " + str(userid)
+            args.append(f"-U {userid}")
         if rd is not None and not rd:
-            cmd = cmd + " -r"
-        cmd = cmd + " " + str(qname)
+            args.append("-r")
+        if tcp is not None and tcp:
+            args.append("-T")
+        args.append(f"{qname}")
 
+        cmd = ' '.join(args)
         c = clibscamperctrl.scamper_inst_do((<ScamperInst>inst)._c,
                                             cmd.encode('UTF-8'), NULL)
         if c == NULL:
@@ -8107,7 +8670,8 @@ cdef class ScamperCtrl:
         :rtype: ScamperTask
         """
 
-        cmd = "dealias -m ally"
+        args = []
+        args.append("dealias -m ally")
         inst = self._getinst(inst)
 
         if method is not None:
@@ -8133,33 +8697,36 @@ cdef class ScamperCtrl:
 
         # if user specifies a method, then construct a probedef
         if m is not None:
-            cmd = cmd + " -p '-P " + m
+            pd = []
+            pd.append(f"-p '-P {m}")
             if sport is not None:
-                cmd = cmd + " -F " + str(sport)
+                pd.append(f" -F {sport}")
             if dport is not None:
-                cmd = cmd + " -d " + str(dport)
+                pd.append(f" -d {dport}")
             if icmp_sum is not None:
-                cmd = cmd + " -c " + str(icmp_sum)
-            cmd = cmd + "'"
+                pd.append(f" -c {icmp_sum}")
+            pd.append("'")
+            args.append(''.join(pd))
 
         # other parameters to the dealias method
         if fudge is not None:
             if fudge == 0:
-                cmd = cmd + " -O inseq"
+                args.append("-O inseq")
             else:
-                cmd = cmd + " -f " + str(fudge)
+                args.append(f"-f {fudge}")
         if userid is not None:
-            cmd = cmd + " -U " + str(userid)
+            args.append(f"-U {userid}")
         if wait_probe is not None:
             if not isinstance(wait_probe, datetime.timedelta):
                 wait_probe = datetime.timedelta(seconds=wait_probe)
-            cmd += f" -W {wait_probe.total_seconds()}s"
+            args.append(f"-W {wait_probe.total_seconds()}s")
         if wait_timeout is not None:
             if not isinstance(wait_timeout, datetime.timedelta):
                 wait_timeout = datetime.timedelta(seconds=wait_timeout)
-            cmd += f" -w {wait_timeout.total_seconds()}s"
-        cmd = cmd + " " + str(dst1) + " " + str(dst2)
+            args.append(f"-w {wait_timeout.total_seconds()}s")
+        args.append(f"{dst1} {dst2}")
 
+        cmd = ' '.join(args)
         c = clibscamperctrl.scamper_inst_do((<ScamperInst>inst)._c,
                                             cmd.encode('UTF-8'), NULL)
         if c == NULL:
@@ -8181,13 +8748,15 @@ cdef class ScamperCtrl:
         :rtype: ScamperTask
         """
 
-        cmd = "dealias -m mercator"
+        args = []
+        args.append("dealias -m mercator")
         inst = self._getinst(inst)
 
         if userid is not None:
-            cmd = cmd + " -U " + str(userid)
-        cmd = cmd + " " + str(dst)
+            args.append(f"-U {userid}")
+        args.append(f"{dst}")
 
+        cmd = ' '.join(args)
         c = clibscamperctrl.scamper_inst_do((<ScamperInst>inst)._c,
                                             cmd.encode('UTF-8'), NULL)
         if c == NULL:
@@ -8219,7 +8788,9 @@ cdef class ScamperCtrl:
         :returns: a task object representing the midarest alias resolution
         :rtype: ScamperTask
         """
-        cmd = "dealias -m midarest"
+
+        args = []
+        args.append("dealias -m midarest")
         inst = self._getinst(inst)
 
         if probedefs is None:
@@ -8230,42 +8801,43 @@ cdef class ScamperCtrl:
         if rounds is not None:
             if not isinstance(rounds, int):
                 raise ValueError("rounds not an integer")
-            cmd += f" -q {rounds}"
+            args.append(f"-q {rounds}")
         if userid is not None:
             if not isinstance(userid, int):
                 raise ValueError("userid not an integer")
-            cmd += f" -U {userid}"
+            args.append(f"-U {userid}")
         if wait_probe is not None:
             if not isinstance(wait_probe, datetime.timedelta):
                 wait_probe = datetime.timedelta(seconds=wait_probe)
             ms = int(wait_probe.seconds * 1000) + int(wait_probe.microseconds / 1000)
             if ms <= 0:
                 raise ValueError("wait_probe must be at least 1ms")
-            cmd += f" -W {ms}"
+            args.append(f"-W {ms}")
         if wait_timeout is not None:
             if not isinstance(wait_timeout, datetime.timedelta):
                 wait_timeout = datetime.timedelta(seconds=wait_timeout)
             s = int(wait_timeout.seconds)
             if s <= 0:
                 raise ValueError("wait_timeout must be at least 1s")
-            cmd += f" -w {s}"
+            args.append(f"-w {s}")
         if wait_round is not None:
             if not isinstance(wait_round, datetime.timedelta):
                 wait_round = datetime.timedelta(seconds=wait_round)
             ms = int(wait_round.seconds * 1000) + int(wait_round.microseconds / 1000)
             if ms <= 0:
                 raise ValueError("wait_round must be at least 1ms")
-            cmd += f" -r {ms}"
+            args.append(f"-r {ms}")
 
         for pd in probedefs:
             if not isinstance(pd, ScamperDealiasProbedef):
                 raise ValueError("expected probedef in probedefs")
-            cmd += f" -p '{pd}'"
+            args.append(f"-p '{pd}'")
         for addr in addrs:
-            if not isinstance(addr, str):
+            if not isinstance(addr, str) and not isinstance(addr, ScamperAddr):
                 raise ValueError("expected str in addrs")
-            cmd += f" {addr}"
+            args.append(f"{addr}")
 
+        cmd = ' '.join(args)
         c = clibscamperctrl.scamper_inst_do((<ScamperInst>inst)._c,
                                             cmd.encode('UTF-8'), NULL)
         if c == NULL:
@@ -8294,7 +8866,9 @@ cdef class ScamperCtrl:
         :returns: a task object representing the midardisc alias resolution
         :rtype: ScamperTask
         """
-        cmd = "dealias -m midardisc"
+
+        args = []
+        args.append("dealias -m midardisc")
         inst = self._getinst(inst)
 
         if probedefs is None:
@@ -8305,31 +8879,32 @@ cdef class ScamperCtrl:
         if userid is not None:
             if not isinstance(userid, int):
                 raise ValueError("userid not an integer")
-            cmd += f" -U {userid}"
+            args.append(f"-U {userid}")
         if wait_timeout is not None:
             if not isinstance(wait_timeout, datetime.timedelta):
                 wait_timeout = datetime.timedelta(seconds=wait_timeout)
             s = int(wait_timeout.seconds)
             if s <= 0:
                 raise ValueError("wait_timeout must be at least 1s")
-            cmd += f" -w {s}"
+            args.append(f"-w {s}")
         if startat is not None:
             if not isinstance(startat, datetime.datetime):
                 raise ValueError("startat not a datetime")
-            cmd += f" -@ {startat.timestamp()}"
+            args.append(f"-@ {startat.timestamp()}")
 
         for pd in probedefs:
             if not isinstance(pd, ScamperDealiasProbedef):
                 raise ValueError("expected probedef in probedefs")
             if pd.dst is None:
                 raise ValueError("missing IP address in probedef")
-            cmd += f" -p '{pd}'"
+            args.append(f"-p '{pd}'")
 
         for s in schedule:
             if not isinstance(s, ScamperDealiasMidardiscRound):
                 raise ValueError("expected round in schedule")
-            cmd += f" -S {s}"
+            args.append(f"-S {s}")
 
+        cmd = ' '.join(args)
         c = clibscamperctrl.scamper_inst_do((<ScamperInst>inst)._c,
                                             cmd.encode('UTF-8'), NULL)
         if c == NULL:
@@ -8367,7 +8942,9 @@ cdef class ScamperCtrl:
         :returns: a task object representing the radargun alias resolution
         :rtype: ScamperTask
         """
-        cmd = "dealias -m radargun"
+
+        args = []
+        args.append("dealias -m radargun")
         inst = self._getinst(inst)
 
         if probedefs is None:
@@ -8376,33 +8953,33 @@ cdef class ScamperCtrl:
         if rounds is not None:
             if not isinstance(rounds, int):
                 raise ValueError("rounds not an integer")
-            cmd += f" -q {rounds}"
+            args.append(f"-q {rounds}")
 
         if userid is not None:
             if not isinstance(userid, int):
                 raise ValueError("userid not an integer")
-            cmd += f" -U {userid}"
+            args.append(f"-U {userid}")
 
         if wait_probe is not None:
             if not isinstance(wait_probe, datetime.timedelta):
                 wait_probe = datetime.timedelta(seconds=wait_probe)
             if wait_probe <= datetime.timedelta(seconds=0):
                 raise ValueError("wait_probe must be greater than zero")
-            cmd += f" -W {wait_probe.total_seconds()}s"
+            args.append(f"-W {wait_probe.total_seconds()}s")
 
         if wait_round is not None:
             if not isinstance(wait_round, datetime.timedelta):
                 wait_round = datetime.timedelta(seconds=wait_round)
             if wait_round <= datetime.timedelta(seconds=0):
                 raise ValueError("wait_round must be greater than zero")
-            cmd += f" -r {wait_round.total_seconds()}s"
+            args.append(f"-r {wait_round.total_seconds()}s")
 
         if wait_timeout is not None:
             if not isinstance(wait_timeout, datetime.timedelta):
                 wait_timeout = datetime.timedelta(seconds=wait_timeout)
             if not wait_timeout >= datetime.timedelta(seconds=1):
                 raise ValueError("wait_timeout must be at least 1s")
-            cmd += f" -w {wait_timeout.total_seconds()}s"
+            args.append(f"-w {wait_timeout.total_seconds()}s")
 
         for pd in probedefs:
             if not isinstance(pd, ScamperDealiasProbedef):
@@ -8411,12 +8988,13 @@ cdef class ScamperCtrl:
                 raise ValueError("missing IP address in probedef")
             elif addrs is not None and pd.dst is not None:
                 raise ValueError("unexpected IP address in probedef")
-            cmd += f" -p '{pd}'"
+            args.append(f"-p '{pd}'")
 
         if addrs is not None:
             for a in addrs:
-                cmd += f" {a}"
+                args.append(f"{a}")
 
+        cmd = ' '.join(args)
         c = clibscamperctrl.scamper_inst_do((<ScamperInst>inst)._c,
                                             cmd.encode('UTF-8'), NULL)
         if c == NULL:
@@ -8466,7 +9044,8 @@ cdef class ScamperCtrl:
         :rtype: ScamperTask
         """
 
-        cmd = "dealias -m prefixscan"
+        args = []
+        args.append("dealias -m prefixscan")
         inst = self._getinst(inst)
 
         if method is not None:
@@ -8500,34 +9079,37 @@ cdef class ScamperCtrl:
 
         # if user specifies a method, then construct a probedef
         if m is not None:
-            cmd = cmd + " -p '-P " + m
+            pd = []
+            pd.append(f"-p '-P {m}")
             if sport is not None:
-                cmd = cmd + " -F " + str(sport)
+                pd.append(f" -F {sport}")
             if dport is not None:
-                cmd = cmd + " -d " + str(dport)
+                pd.append(f" -d {dport}")
             if icmp_sum is not None:
-                cmd = cmd + " -c " + str(icmp_sum)
-            cmd = cmd + "'"
+                pd.append(f" -c {icmp_sum}")
+            pd.append("'")
+            args.append(''.join(pd))
 
         # other parameters to the dealias method
         if fudge is not None:
             if fudge == 0:
-                cmd = cmd + " -O inseq"
+                args.append("-O inseq")
             else:
-                cmd = cmd + " -f " + str(fudge)
+                args.append(f"-f {fudge}")
         if userid is not None:
-            cmd = cmd + " -U " + str(userid)
+            args.append(f"-U {userid}")
         if wait_probe is not None:
             if not isinstance(wait_probe, datetime.timedelta):
                 wait_probe = datetime.timedelta(seconds=wait_probe)
-            cmd += f" -W {wait_probe.total_seconds()}s"
+            args.append(f"-W {wait_probe.total_seconds()}s")
         if wait_timeout is not None:
             if not isinstance(wait_timeout, datetime.timedelta):
                 wait_timeout = datetime.timedelta(seconds=wait_timeout)
-            cmd += f" -w {wait_timeout.total_seconds()}s"
+            args.append(f"-w {wait_timeout.total_seconds()}s")
 
-        cmd = cmd + " " + str(near) + " " + str(far) + "/" + str(prefixlen)
+        args.append(f"{near} {far}/{prefixlen}")
 
+        cmd = ' '.join(args)
         c = clibscamperctrl.scamper_inst_do((<ScamperInst>inst)._c,
                                             cmd.encode('UTF-8'), NULL)
         if c == NULL:
@@ -8554,7 +9136,8 @@ cdef class ScamperCtrl:
         :rtype: ScamperTask
         """
 
-        cmd = "sniff -S " + str(src)
+        args = []
+        args.append(f"sniff -S {src}")
         inst = self._getinst(inst)
 
         if icmp_id < 0 or icmp_id > 65535:
@@ -8565,16 +9148,17 @@ cdef class ScamperCtrl:
             raise ValueError("invalid limit_time")
 
         if limit_pkt_count is not None:
-            cmd = cmd + " -c " + str(limit_pkt_count)
+            args.append(f"-c {limit_pkt_count}")
         if limit_time is not None:
             if not isinstance(limit_time, datetime.timedelta):
                 limit_time = datetime.timedelta(seconds=limit_time)
-            cmd += f" -G {limit_time.total_seconds()}s"
+            args.append(f"-G {limit_time.total_seconds()}s")
         if userid is not None:
-            cmd = cmd + " -U " + str(userid)
+            args.append(f"-U {userid}")
 
-        cmd = cmd + " icmp[icmpid] == " + str(icmp_id)
+        args.append(f"icmp[icmpid] == {icmp_id}")
 
+        cmd = ' '.join(args)
         c = clibscamperctrl.scamper_inst_do((<ScamperInst>inst)._c,
                                             cmd.encode('UTF-8'), NULL)
         if c == NULL:
@@ -8603,7 +9187,8 @@ cdef class ScamperCtrl:
         :rtype: ScamperTask
         """
 
-        cmd = "http"
+        args = []
+        args.append("http")
         inst = self._getinst(inst)
 
         if dst is None:
@@ -8612,12 +9197,12 @@ cdef class ScamperCtrl:
             raise ValueError("invalid url")
 
         if insecure is True:
-            cmd = cmd + " -O insecure"
+            args.append("-O insecure")
 
         if limit_time is not None:
             if not isinstance(limit_time, datetime.timedelta):
                 limit_time = datetime.timedelta(seconds=limit_time)
-            cmd = cmd + f" -m {limit_time.total_seconds()}s"
+            args.append(f"-m {limit_time.total_seconds()}s")
 
         if headers is not None:
             if not isinstance(headers, dict):
@@ -8628,19 +9213,23 @@ cdef class ScamperCtrl:
                 fbody = headers[fname]
                 if not isinstance(fbody, str) or not fbody.isascii():
                     raise ValueError("header field-body is not ascii")
-                cmd = cmd + f" -H '{fname}: {fbody}'"
+                args.append(f"-H '{fname}: {fbody}'")
 
-        cmd = cmd + " -u '" + str(url) + "' " + str(dst)
+        esc = str(url).replace("'", "\\'")
+        args.append(f"-u '{esc}' {dst}")
+
+        cmd = ' '.join(args)
         c = clibscamperctrl.scamper_inst_do((<ScamperInst>inst)._c,
                                             cmd.encode('UTF-8'), NULL)
         if c == NULL:
             raise RuntimeError("could not schedule command")
         return self._task(c, (<ScamperInst>inst)._c, sync)
 
-    def do_udpprobe(self, dst, dport, payload,
-                    inst=None, userid=None, sync=False):
+    def do_udpprobe(self, dst, dport, payload, attempts=None,
+                    stop_count=None, inst=None, userid=None, sync=False):
         """
-        do_udpprobe(dst, dport, payload, inst=None, userid=None, sync=False)
+        do_udpprobe(dst, dport, payload, attempts=None, stop_count=None,\
+                    inst=None, userid=None, sync=False)
         conduct a UDP probe specified destination, port, and payload.
         If this method could not queue the measurement,
         it will raise a :py:exc:`RuntimeError` exception.
@@ -8648,15 +9237,18 @@ cdef class ScamperCtrl:
         :param string dst: the destination address to send the probe to
         :param int dport: the destination port to send the probe to
         :param bytes payload: the payload to include in the probe
-        :param int userid: the userid value to tag with this measurement
+        :param int attempts: the number of probes to send
+        :param int stop_count: stop after receiving replies to this many probes
         :param ScamperInst inst: The specific instance to issue command over
+        :param int userid: the userid value to tag with this measurement
         :param bool sync: operate the measurement synchronously
             (the method returns when the measurement completes).
         :returns: an object representing the UDP probe task.
         :rtype: ScamperTask
         """
 
-        cmd = "udpprobe"
+        args = []
+        args.append("udpprobe")
         inst = self._getinst(inst)
 
         if dst is None or dport is None or payload is None:
@@ -8664,13 +9256,57 @@ cdef class ScamperCtrl:
         if dport < 1 or dport > 65535:
             raise ValueError(f"invalid destination port {dport}")
 
+        args.append(f"-d {dport}")
+        args.append(f"-p {binascii.hexlify(payload).decode('ascii')}")
+        if attempts is not None:
+            args.append(f"-c {attempts}")
+        if stop_count is not None:
+            args.append(f"-o {stop_count}")
         if userid is not None:
-            cmd = cmd + " -U " + userid
+            args.append(f"-U {userid}")
+        args.append(f"{dst}")
 
-        cmd = cmd + f" -d {dport}"
-        cmd = cmd + " -p " + binascii.hexlify(payload).decode('ascii')
-        cmd = cmd + f" {dst}"
+        cmd = ' '.join(args)
+        c = clibscamperctrl.scamper_inst_do((<ScamperInst>inst)._c,
+                                            cmd.encode('UTF-8'), NULL)
+        if c == NULL:
+            raise RuntimeError("could not schedule command")
+        return self._task(c, (<ScamperInst>inst)._c, sync)
 
+    def do_tbit(self, dst, method=None, url=None,
+                inst=None, userid=None, sync=False):
+        """
+        do_tbit(dst, method=None, url=None,
+                inst=None, userid=None, sync=False)
+        conduct a TBIT test using the specified destination and method.
+        If this method could not queue the measurement,
+        it will raise a :py:exc:`RuntimeError` exception.
+
+        :param string dst: the destination address to measure
+        :param string method: the tbit test method to use
+        :param string url: a URL specifying an object to fetch as part of test
+        :param ScamperInst inst: The specific instance to issue command over
+        :param int userid: the userid value to tag with this measurement
+        :param bool sync: operate the measurement synchronously
+            (the method returns when the measurement completes).
+        :returns: an object representing the UDP probe task.
+        :rtype: ScamperTask
+        """
+
+        args = []
+        args.append("tbit")
+        inst = self._getinst(inst)
+
+        if dst is None or method is None or url is None:
+            raise ValueError("must specify dst, method, and url")
+
+        if userid is not None:
+            args.append(f"-U {userid}")
+
+        esc = str(url).replace("'", "\\'")
+        args.append(f"-u '{esc}' -t {method} {dst}")
+
+        cmd = ' '.join(args)
         c = clibscamperctrl.scamper_inst_do((<ScamperInst>inst)._c,
                                             cmd.encode('UTF-8'), NULL)
         if c == NULL:
@@ -8704,8 +9340,9 @@ cdef class ScamperInst:
         raise TypeError("This class cannot be instantiated directly.")
 
     def __dealloc__(self):
-        while len(self._tasks) > 0:
-            self._tasks.pop(0)
+        if self._tasks is not None:
+            while len(self._tasks) > 0:
+                self._tasks.pop(0)
         if self._c_f != NULL:
             cscamper_file.scamper_file_close(self._c_f)
         if self._c_rb != NULL:
@@ -8713,35 +9350,22 @@ cdef class ScamperInst:
         if self._c != NULL:
             clibscamperctrl.scamper_inst_free(self._c)
 
-    def __eq__(self, other):
+    def __richcmp__(self, other, int op):
         if not isinstance(other, ScamperInst):
             return NotImplemented
-        return self._c == (<ScamperInst>other)._c
-
-    def __ne__(self, other):
-        if not isinstance(other, ScamperInst):
-            return NotImplemented
-        return self._c != (<ScamperInst>other)._c
-
-    def __lt__(self, other):
-        if not isinstance(other, ScamperInst):
-            return NotImplemented
-        return self._c < (<ScamperInst>other)._c
-
-    def __le__(self, other):
-        if not isinstance(other, ScamperInst):
-            return NotImplemented
-        return self._c <= (<ScamperInst>other)._c
-
-    def __gt__(self, other):
-        if not isinstance(other, ScamperInst):
-            return NotImplemented
-        return self._c > (<ScamperInst>other)._c
-
-    def __ge__(self, other):
-        if not isinstance(other, ScamperInst):
-            return NotImplemented
-        return self._c >= (<ScamperInst>other)._c
+        if op == Py_EQ:
+            return self._c == (<ScamperInst>other)._c
+        elif op == Py_NE:
+            return self._c != (<ScamperInst>other)._c
+        elif op == Py_LT:
+            return self._c <  (<ScamperInst>other)._c
+        elif op == Py_LE:
+            return self._c <= (<ScamperInst>other)._c
+        elif op == Py_GT:
+            return self._c >  (<ScamperInst>other)._c
+        elif op == Py_GE:
+            return self._c >= (<ScamperInst>other)._c
+        return NotImplemented
 
     def __hash__(self):
         return hash((<Py_ssize_t>self._c))
@@ -8810,35 +9434,22 @@ cdef class ScamperTask:
         if self._c != NULL:
             clibscamperctrl.scamper_task_free(self._c)
 
-    def __eq__(self, other):
+    def __richcmp__(self, other, int op):
         if not isinstance(other, ScamperTask):
             return NotImplemented
-        return self._c == (<ScamperTask>other)._c
-
-    def __ne__(self, other):
-        if not isinstance(other, ScamperTask):
-            return NotImplemented
-        return self._c != (<ScamperTask>other)._c
-
-    def __lt__(self, other):
-        if not isinstance(other, ScamperTask):
-            return NotImplemented
-        return self._c < (<ScamperTask>other)._c
-
-    def __le__(self, other):
-        if not isinstance(other, ScamperTask):
-            return NotImplemented
-        return self._c <= (<ScamperTask>other)._c
-
-    def __gt__(self, other):
-        if not isinstance(other, ScamperTask):
-            return NotImplemented
-        return self._c > (<ScamperTask>other)._c
-
-    def __ge__(self, other):
-        if not isinstance(other, ScamperTask):
-            return NotImplemented
-        return self._c >= (<ScamperTask>other)._c
+        if op == Py_EQ:
+            return self._c == (<ScamperTask>other)._c
+        if op == Py_NE:
+            return self._c != (<ScamperTask>other)._c
+        if op == Py_LT:
+            return self._c <  (<ScamperTask>other)._c
+        if op == Py_LE:
+            return self._c <= (<ScamperTask>other)._c
+        if op == Py_GT:
+            return self._c >  (<ScamperTask>other)._c
+        if op == Py_GE:
+            return self._c >= (<ScamperTask>other)._c
+        return NotImplemented
 
     def __hash__(self):
         return hash((<Py_ssize_t>self._c))

--- a/mjl_list.c
+++ b/mjl_list.c
@@ -1,7 +1,7 @@
 /*
  * linked list routines
  *
- * $Id: mjl_list.c,v 1.81 2023/08/18 05:41:23 mjl Exp $
+ * $Id: mjl_list.c,v 1.83 2024/03/23 07:55:43 mjl Exp $
  *
  *        Matthew Luckie
  *        mjl@luckie.org.nz

--- a/mjl_list.h
+++ b/mjl_list.h
@@ -25,7 +25,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * $Id: mjl_list.h,v 1.42 2023/04/14 04:01:55 mjl Exp $
+ * $Id: mjl_list.h,v 1.44 2024/03/23 07:55:43 mjl Exp $
  *
  */
 

--- a/mjl_prefixtree.c
+++ b/mjl_prefixtree.c
@@ -31,7 +31,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * $Id: mjl_prefixtree.c,v 1.20 2023/08/18 21:32:20 mjl Exp $
+ * $Id: mjl_prefixtree.c,v 1.21 2024/03/04 19:36:41 mjl Exp $
  *
  */
 
@@ -476,7 +476,7 @@ int prefix6_isvalid(const struct in6_addr *net, uint8_t len)
     }
 #endif
 
-  return 1;     
+  return 1;
 }
 
 prefix4_t *prefixtree_find_ip4(const prefixtree_t *tree,
@@ -678,7 +678,7 @@ prefixtree_node_t *prefixtree_insert4_dm(prefixtree_t *tree, prefix4_t *pref,
     bit = x->bit;
   else
     bit = pref->len;
-  
+
   /* get the first bit different between the two prefixes */
   fbd = prefix4_fbd(x->pref.v4, pref);
   if(fbd > bit)
@@ -824,7 +824,7 @@ prefixtree_node_t *prefixtree_insert6_dm(prefixtree_t *tree, prefix6_t *pref,
     bit = x->bit;
   else
     bit = pref->len;
-  
+
   /* get the first bit different between the two prefixes */
   fbd = prefix6_fbd(x->pref.v6, pref);
   if(fbd > bit)

--- a/scamper/Makefile.am
+++ b/scamper/Makefile.am
@@ -1,4 +1,4 @@
-# $Id: Makefile.am,v 1.72 2024/02/29 01:35:31 mjl Exp $
+# $Id: Makefile.am,v 1.76 2024/05/02 21:21:47 mjl Exp $
 
 AUTOMAKE_OPTIONS = subdir-objects
 
@@ -10,7 +10,7 @@ lib_LTLIBRARIES = libscamperfile.la
 
 libscamperfile_la_CFLAGS = -DBUILDING_LIBSCAMPERFILE
 
-libscamperfile_la_LDFLAGS = -version-info 8:1:0 \
+libscamperfile_la_LDFLAGS = -version-info 9:0:0 \
 	-export-symbols-regex '^scamper_'
 
 libscamperfile_la_LIBADD = @ZLIB_LIBS@ @LIBBZ2_LIBS@ @LIBLZMA_LIBS@ @WINSOCK_LIBS@
@@ -26,6 +26,7 @@ libscamperfile_la_SOURCES = \
 	scamper_list.c \
 	scamper_icmpext.c \
 	scamper_icmpext_lib.c \
+	scamper_ifname.c \
 	trace/scamper_trace.c \
 	trace/scamper_trace_warts.c \
 	trace/scamper_trace_text.c \
@@ -91,6 +92,8 @@ scamper_SOURCES = \
 	scamper_icmp_resp.c \
 	scamper_icmpext.c \
 	scamper_icmpext_int.c \
+	scamper_ifname.c \
+	scamper_ifname_int.c \
 	scamper_tcp4.c \
 	scamper_tcp6.c \
 	scamper_ip6.c \

--- a/scamper/dealias/scamper_dealias.c
+++ b/scamper/dealias/scamper_dealias.c
@@ -1,7 +1,7 @@
 /*
  * scamper_dealias.c
  *
- * $Id: scamper_dealias.c,v 1.73 2023/12/29 03:46:11 mjl Exp $
+ * $Id: scamper_dealias.c,v 1.74 2024/03/04 19:36:41 mjl Exp $
  *
  * Copyright (C) 2008-2010 The University of Waikato
  * Copyright (C) 2012-2013 The Regents of the University of California
@@ -348,7 +348,7 @@ scamper_dealias_prefixscan_t *scamper_dealias_prefixscan_alloc(void)
 }
 
 void scamper_dealias_prefixscan_free(scamper_dealias_prefixscan_t *prefixscan)
-{  
+{
   uint16_t i;
 
   if(prefixscan == NULL)

--- a/scamper/dealias/scamper_dealias_cmd.c
+++ b/scamper/dealias/scamper_dealias_cmd.c
@@ -1,7 +1,7 @@
 /*
  * scamper_dealias_cmd.c
  *
- * $Id: scamper_dealias_cmd.c,v 1.28 2024/02/15 07:00:24 mjl Exp $
+ * $Id: scamper_dealias_cmd.c,v 1.30 2024/05/02 02:33:38 mjl Exp $
  *
  * Copyright (C) 2008-2011 The University of Waikato
  * Copyright (C) 2012-2013 Matthew Luckie
@@ -522,7 +522,7 @@ static int dealias_alloc_mercator(scamper_dealias_t *d, dealias_options_t *o,
     }
   if((dst = scamper_addrcache_resolve(addrcache, AF_UNSPEC, o->addr)) == NULL)
     {
-      snprintf(errbuf, errlen, "invalid target address: %s", o->addr);
+      snprintf(errbuf, errlen, "invalid target address");
       goto err;
     }
 
@@ -546,7 +546,7 @@ static int dealias_alloc_mercator(scamper_dealias_t *d, dealias_options_t *o,
       goto err;
     }
   mc->attempts = o->attempts;
-  timeval_cpy(&mc->wait_timeout, &o->wait_timeout);  
+  timeval_cpy(&mc->wait_timeout, &o->wait_timeout);
 
   if(o->probedefs == NULL)
     {
@@ -575,12 +575,10 @@ static int dealias_alloc_mercator(scamper_dealias_t *d, dealias_options_t *o,
     }
   mc->probedef->id = 0;
   mc->probedef->dst = dst; dst = NULL;
-
-  d->data = mc;
-
   if(probedef_size_check(mc->probedef, errbuf, errlen) != 0)
     goto err;
 
+  d->data = mc;
   return 0;
 
  err:
@@ -601,7 +599,7 @@ static int dealias_alloc_ally(scamper_dealias_t *d, dealias_options_t *o,
   char *addr2, *pdstr;
 
   memset(&pd, 0, sizeof(pd));
-  
+
   if(o->probedefs != NULL)
     probedefc = slist_count(o->probedefs);
 
@@ -683,13 +681,13 @@ static int dealias_alloc_ally(scamper_dealias_t *d, dealias_options_t *o,
       pd[0].dst = scamper_addrcache_resolve(addrcache, AF_UNSPEC, o->addr);
       if(pd[0].dst == NULL)
 	{
-	  snprintf(errbuf, errlen, "could not resolve %s", o->addr);
+	  snprintf(errbuf, errlen, "could not resolve address");
 	  goto err;
 	}
       pd[1].dst = scamper_addrcache_resolve(addrcache, AF_UNSPEC, addr2);
       if(pd[1].dst == NULL)
 	{
-	  snprintf(errbuf, errlen, "could not resolve %s", addr2);
+	  snprintf(errbuf, errlen, "could not resolve address");
 	  goto err;
 	}
     }
@@ -782,12 +780,12 @@ static int dealias_alloc_radargun(scamper_dealias_t *d, dealias_options_t *o,
 	  a2 = string_nextword(a1);
 	  if((addr = scamper_addrcache_resolve(addrcache,AF_UNSPEC,a1)) == NULL)
 	    {
-	      snprintf(errbuf, errlen, "could not resolve %s", a1);
+	      snprintf(errbuf, errlen, "could not resolve address");
 	      goto err;
 	    }
 	  if(slist_tail_push(addrs, addr) == NULL)
 	    {
-	      snprintf(errbuf, errlen, "could not add %s to list", a1);
+	      snprintf(errbuf, errlen, "could not add address to list");
 	      goto err;
 	    }
 	  addr = NULL;
@@ -1011,7 +1009,7 @@ static int dealias_alloc_prefixscan(scamper_dealias_t *d, dealias_options_t *o,
 
   if(string_tolong(pfxstr, &tmp) != 0 || tmp < 24 || tmp >= 32)
     {
-      snprintf(errbuf, errlen, "invalid prefix %s", pfxstr);
+      snprintf(errbuf, errlen, "invalid prefix");
       goto err;
     }
   prefix = (uint8_t)tmp;
@@ -1047,14 +1045,14 @@ static int dealias_alloc_prefixscan(scamper_dealias_t *d, dealias_options_t *o,
   prefixscan->a = scamper_addrcache_resolve(addrcache, AF_UNSPEC, o->addr);
   if(prefixscan->a == NULL)
     {
-      snprintf(errbuf, errlen, "could not resolve %s", o->addr);
+      snprintf(errbuf, errlen, "could not resolve address");
       goto err;
     }
   af = scamper_addr_af(prefixscan->a);
   prefixscan->b = scamper_addrcache_resolve(addrcache, af, addr2);
   if(prefixscan->b == NULL)
     {
-      snprintf(errbuf, errlen, "could not resolve %s", addr2);
+      snprintf(errbuf, errlen, "could not resolve address");
       goto err;
     }
 
@@ -1080,12 +1078,12 @@ static int dealias_alloc_prefixscan(scamper_dealias_t *d, dealias_options_t *o,
 	  xs = slist_node_item(sn);
 	  if((dst = scamper_addrcache_resolve(addrcache, af, xs)) == NULL)
 	    {
-	      snprintf(errbuf, errlen, "could not resolve %s", xs);
+	      snprintf(errbuf, errlen, "could not resolve address");
 	      goto err;
 	    }
 	  if(scamper_dealias_prefixscan_xs_add(d, dst) != 0)
 	    {
-	      snprintf(errbuf, errlen, "could not add %s to xs", xs);
+	      snprintf(errbuf, errlen, "could not add address to xs");
 	      goto err;
 	    }
 	  scamper_addr_free(dst); dst = NULL;
@@ -1259,12 +1257,12 @@ static int dealias_alloc_midarest(scamper_dealias_t *d, dealias_options_t *o,
       a2 = string_nextword(a1);
       if((addr = scamper_addrcache_resolve(addrcache, AF_INET, a1)) == NULL)
 	{
-	  snprintf(errbuf, errlen, "could not resolve %s as IPv4 address", a1);
+	  snprintf(errbuf, errlen, "could not resolve IPv4 address");
 	  goto err;
 	}
       if(slist_tail_push(addrs, addr) == NULL)
 	{
-	  snprintf(errbuf, errlen, "could not add %s to list", a1);
+	  snprintf(errbuf, errlen, "could not add address to list");
 	  goto err;
 	}
       addr = NULL;
@@ -1583,9 +1581,8 @@ void *scamper_do_dealias_alloc(char *str, char *errbuf, size_t errlen)
 	 dealias_arg_param_validate(opt->id, opt->str, &tmp,
 				    buf, sizeof(buf)) != 0)
 	{
-	  snprintf(errbuf, errlen, "-%c %s failed: %s",
-		   scamper_options_id2c(opts, opts_cnt, opt->id),
-		   opt->str, buf);
+	  snprintf(errbuf, errlen, "-%c failed: %s",
+		   scamper_options_id2c(opts, opts_cnt, opt->id), buf);
 	  goto err;
 	}
 
@@ -1608,7 +1605,7 @@ void *scamper_do_dealias_alloc(char *str, char *errbuf, size_t errlen)
 	    o.inseq = 1;
 	  else
 	    {
-	      snprintf(errbuf, errlen, "-O %s unknown", opt->str);
+	      snprintf(errbuf, errlen, "unknown option");
 	      goto err;
 	    }
 	  break;

--- a/scamper/dealias/scamper_dealias_do.c
+++ b/scamper/dealias/scamper_dealias_do.c
@@ -1,7 +1,7 @@
 /*
  * scamper_do_dealias.c
  *
- * $Id: scamper_dealias_do.c,v 1.198 2024/02/28 04:25:07 mjl Exp $
+ * $Id: scamper_dealias_do.c,v 1.199 2024/03/04 19:36:41 mjl Exp $
  *
  * Copyright (C) 2008-2011 The University of Waikato
  * Copyright (C) 2012-2013 Matthew Luckie
@@ -879,7 +879,7 @@ static int dealias_ally_handlereply_v6(scamper_task_t *task,
 	}
     }
 
-  /* if the response contains an IP-ID, then we're good for this def */  
+  /* if the response contains an IP-ID, then we're good for this def */
   if((reply->flags & SCAMPER_DEALIAS_REPLY_FLAG_IPID32) != 0)
     {
       pd->flags |= DEALIAS_PROBEDEF_FLAG_RX_IPID;
@@ -1029,7 +1029,7 @@ static dealias_probedef_t *
 dealias_radargun_def(scamper_dealias_t *dealias, dealias_state_t *state)
 {
   scamper_dealias_radargun_t *rg = dealias->data;
-  dealias_radargun_t *rgstate = state->methodstate; 
+  dealias_radargun_t *rgstate = state->methodstate;
   if((rg->flags & SCAMPER_DEALIAS_RADARGUN_FLAG_SHUFFLE) == 0)
     return state->pds[state->probe];
   return state->pds[rgstate->order[rgstate->i++]];
@@ -2433,7 +2433,7 @@ static void do_dealias_probe(scamper_task_t *task)
     {
       ptb = slist_head_pop(state->ptbq); def = ptb->def;
       probe.pr_ip_src = def->src;
-      probe.pr_ip_dst = def->dst;      
+      probe.pr_ip_dst = def->dst;
       probe.pr_ip_ttl = 255;
       SCAMPER_PROBE_ICMP_PTB(&probe, def->mtu);
       probe.pr_data   = ptb->quote;

--- a/scamper/host/scamper_host.h
+++ b/scamper/host/scamper_host.h
@@ -1,9 +1,9 @@
 /*
  * scamper_host
  *
- * $Id: scamper_host.h,v 1.22 2023/12/22 18:55:00 mjl Exp $
+ * $Id: scamper_host.h,v 1.25 2024/04/27 21:35:54 mjl Exp $
  *
- * Copyright (C) 2018-2023 Matthew Luckie
+ * Copyright (C) 2018-2024 Matthew Luckie
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,6 +28,7 @@ typedef struct scamper_host_query scamper_host_query_t;
 typedef struct scamper_host_rr scamper_host_rr_t;
 typedef struct scamper_host_rr_soa scamper_host_rr_soa_t;
 typedef struct scamper_host_rr_mx scamper_host_rr_mx_t;
+typedef struct scamper_host_rr_txt scamper_host_rr_txt_t;
 
 void scamper_host_free(scamper_host_t *host);
 char *scamper_host_stop_tostr(const scamper_host_t *h, char *b, size_t l);
@@ -81,6 +82,7 @@ scamper_addr_t *scamper_host_rr_addr_get(const scamper_host_rr_t *rr);
 const char *scamper_host_rr_str_get(const scamper_host_rr_t *rr);
 scamper_host_rr_soa_t *scamper_host_rr_soa_get(const scamper_host_rr_t *rr);
 scamper_host_rr_mx_t *scamper_host_rr_mx_get(const scamper_host_rr_t *rr);
+scamper_host_rr_txt_t *scamper_host_rr_txt_get(const scamper_host_rr_t *rr);
 
 scamper_host_rr_mx_t *scamper_host_rr_mx_use(scamper_host_rr_mx_t *mx);
 void scamper_host_rr_mx_free(scamper_host_rr_mx_t *mx);
@@ -97,9 +99,16 @@ uint32_t scamper_host_rr_soa_retry_get(const scamper_host_rr_soa_t *soa);
 uint32_t scamper_host_rr_soa_expire_get(const scamper_host_rr_soa_t *soa);
 uint32_t scamper_host_rr_soa_minimum_get(const scamper_host_rr_soa_t *soa);
 
+scamper_host_rr_txt_t *scamper_host_rr_txt_use(scamper_host_rr_txt_t *txt);
+void scamper_host_rr_txt_free(scamper_host_rr_txt_t *txt);
+uint16_t scamper_host_rr_txt_strc_get(const scamper_host_rr_txt_t *txt);
+const char *scamper_host_rr_txt_str_get(const scamper_host_rr_txt_t *txt, uint16_t i);
+
 #define SCAMPER_HOST_FLAG_NORECURSE 0x0001
+#define SCAMPER_HOST_FLAG_TCP       0x0002
 
 #define SCAMPER_HOST_CLASS_IN     1
+#define SCAMPER_HOST_CLASS_CH     3
 
 #define SCAMPER_HOST_TYPE_A       1
 #define SCAMPER_HOST_TYPE_NS      2
@@ -145,5 +154,6 @@ uint32_t scamper_host_rr_soa_minimum_get(const scamper_host_rr_soa_t *soa);
 #define SCAMPER_HOST_RR_DATA_TYPE_STR  2
 #define SCAMPER_HOST_RR_DATA_TYPE_SOA  3
 #define SCAMPER_HOST_RR_DATA_TYPE_MX   4
+#define SCAMPER_HOST_RR_DATA_TYPE_TXT  5
 
 #endif /* __SCAMPER_HOST_H */

--- a/scamper/host/scamper_host_int.h
+++ b/scamper/host/scamper_host_int.h
@@ -1,7 +1,7 @@
 /*
  * scamper_host_int.h
  *
- * $Id: scamper_host_int.h,v 1.5 2023/12/22 18:55:00 mjl Exp $
+ * $Id: scamper_host_int.h,v 1.6 2024/04/20 00:15:02 mjl Exp $
  *
  * Copyright (C) 2018-2023 Matthew Luckie
  *
@@ -31,11 +31,22 @@ scamper_host_rr_t *scamper_host_rr_alloc(const char *,
 					 uint16_t, uint16_t, uint32_t);
 scamper_host_rr_mx_t *scamper_host_rr_mx_alloc(uint16_t, const char *);
 scamper_host_rr_soa_t *scamper_host_rr_soa_alloc(const char *, const char *);
+scamper_host_rr_txt_t *scamper_host_rr_txt_alloc(uint16_t strc);
 
 struct scamper_host_rr_mx
 {
   uint16_t                 preference;
   char                    *exchange;
+
+#ifdef BUILDING_LIBSCAMPERFILE
+  int                      refcnt;
+#endif
+};
+
+struct scamper_host_rr_txt
+{
+  char                   **strs;
+  uint16_t                 strc;
 
 #ifdef BUILDING_LIBSCAMPERFILE
   int                      refcnt;
@@ -70,6 +81,7 @@ struct scamper_host_rr
     char                  *str;
     scamper_host_rr_soa_t *soa;
     scamper_host_rr_mx_t  *mx;
+    scamper_host_rr_txt_t *txt;
   } un;
 
 #ifdef BUILDING_LIBSCAMPERFILE

--- a/scamper/host/scamper_host_lib.c
+++ b/scamper/host/scamper_host_lib.c
@@ -1,9 +1,9 @@
 /*
  * scamper_host_lib.c
  *
- * $Id: scamper_host_lib.c,v 1.8 2023/12/22 18:55:00 mjl Exp $
+ * $Id: scamper_host_lib.c,v 1.9 2024/04/20 00:15:02 mjl Exp $
  *
- * Copyright (C) 2023 Matthew Luckie
+ * Copyright (C) 2023-2024 Matthew Luckie
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -241,6 +241,14 @@ scamper_host_rr_mx_t *scamper_host_rr_mx_get(const scamper_host_rr_t *rr)
   return rr->un.mx;
 }
 
+scamper_host_rr_txt_t *scamper_host_rr_txt_get(const scamper_host_rr_t *rr)
+{
+  if(scamper_host_rr_data_type(rr->class, rr->type) !=
+     SCAMPER_HOST_RR_DATA_TYPE_TXT)
+    return NULL;
+  return rr->un.txt;
+}
+
 #ifdef BUILDING_LIBSCAMPERFILE
 scamper_host_rr_mx_t *scamper_host_rr_mx_use(scamper_host_rr_mx_t *mx)
 {
@@ -300,4 +308,24 @@ uint32_t scamper_host_rr_soa_expire_get(const scamper_host_rr_soa_t *soa)
 uint32_t scamper_host_rr_soa_minimum_get(const scamper_host_rr_soa_t *soa)
 {
   return soa->minimum;
+}
+
+#ifdef BUILDING_LIBSCAMPERFILE
+scamper_host_rr_txt_t *scamper_host_rr_txt_use(scamper_host_rr_txt_t *txt)
+{
+  txt->refcnt++;
+  return txt;
+}
+#endif
+
+uint16_t scamper_host_rr_txt_strc_get(const scamper_host_rr_txt_t *txt)
+{
+  return txt->strc;
+}
+
+const char *scamper_host_rr_txt_str_get(const scamper_host_rr_txt_t *txt, uint16_t i)
+{
+  if(txt != NULL && txt->strs != NULL && i < txt->strc)
+    return txt->strs[i];
+  return NULL;
 }

--- a/scamper/http/scamper_http_cmd.c
+++ b/scamper/http/scamper_http_cmd.c
@@ -1,7 +1,7 @@
 /*
  * scamper_http_cmd.c
  *
- * $Id: scamper_http_cmd.c,v 1.6 2024/02/15 07:43:23 mjl Exp $
+ * $Id: scamper_http_cmd.c,v 1.8 2024/05/02 02:33:38 mjl Exp $
  *
  * Copyright (C) 2023-2024 The Regents of the University of California
  *
@@ -84,7 +84,7 @@ static int http_header_validate(const char *header)
   /* check that the field-body is well formed */
   while(*ptr != '\0')
     {
-      if(isprint(*ptr) == 0)
+      if(isprint((unsigned char)*ptr) == 0)
 	return -1;
       ptr++;
     }
@@ -135,7 +135,7 @@ static int http_arg_param_validate(int optid, char *param, long long *out,
 	tmp = SCAMPER_HTTP_FLAG_INSECURE;
       else
 	{
-	  snprintf(errbuf, errlen, "-O %s unknown", param);
+	  snprintf(errbuf, errlen, "unknown option");
 	  goto err;
 	}
       break;
@@ -218,9 +218,8 @@ void *scamper_do_http_alloc(char *str, char *errbuf, size_t errlen)
 	 http_arg_param_validate(opt->id, opt->str, &tmp,
 				 buf, sizeof(buf)) != 0)
 	{
-	  snprintf(errbuf, errlen, "-%c %s failed: %s",
-		   scamper_options_id2c(opts, opts_cnt, opt->id),
-		   opt->str, buf);
+	  snprintf(errbuf, errlen, "-%c failed: %s",
+		   scamper_options_id2c(opts, opts_cnt, opt->id), buf);
 	  goto err;
 	}
 

--- a/scamper/neighbourdisc/scamper_neighbourdisc_do.c
+++ b/scamper/neighbourdisc/scamper_neighbourdisc_do.c
@@ -1,7 +1,7 @@
 /*
  * scamper_do_neighbourdisc
  *
- * $Id: scamper_neighbourdisc_do.c,v 1.48 2024/02/27 03:34:02 mjl Exp $
+ * $Id: scamper_neighbourdisc_do.c,v 1.49 2024/07/02 01:11:17 mjl Exp $
  *
  * Copyright (C) 2009-2023 Matthew Luckie
  *
@@ -32,6 +32,7 @@
 #include "scamper_neighbourdisc.h"
 #include "scamper_neighbourdisc_int.h"
 #include "scamper_dl.h"
+#include "scamper_dlhdr.h"
 #include "scamper_fds.h"
 #include "scamper_probe.h"
 #include "scamper_task.h"

--- a/scamper/ping/scamper_ping.c
+++ b/scamper/ping/scamper_ping.c
@@ -7,7 +7,7 @@
  * Copyright (C) 2020-2023 Matthew Luckie
  * Author: Matthew Luckie
  *
- * $Id: scamper_ping.c,v 1.52 2023/07/25 08:46:24 mjl Exp $
+ * $Id: scamper_ping.c,v 1.53 2024/05/01 07:46:20 mjl Exp $
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,6 +32,7 @@
 #include "scamper_list.h"
 #include "scamper_addr.h"
 #include "scamper_addr_int.h"
+#include "scamper_ifname.h"
 #include "scamper_ping.h"
 #include "scamper_ping_int.h"
 
@@ -411,6 +412,9 @@ void scamper_ping_reply_free(scamper_ping_reply_t *reply)
 
   if(reply->tsreply != NULL)
     scamper_ping_reply_tsreply_free(reply->tsreply);
+
+  if(reply->ifname != NULL)
+    scamper_ifname_free(reply->ifname);
 
   free(reply);
   return;

--- a/scamper/ping/scamper_ping.h
+++ b/scamper/ping/scamper_ping.h
@@ -1,7 +1,7 @@
 /*
  * scamper_ping.h
  *
- * $Id: scamper_ping.h,v 1.72 2024/02/28 23:35:23 mjl Exp $
+ * $Id: scamper_ping.h,v 1.75 2024/06/26 20:05:29 mjl Exp $
  *
  * Copyright (C) 2005-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -45,6 +45,7 @@ typedef struct scamper_ping_stats scamper_ping_stats_t;
 #define SCAMPER_PING_REPLY_FLAG_PROBE_IPID 0x04 /* probe ipid included */
 #define SCAMPER_PING_REPLY_FLAG_DLTX       0x08 /* datalink tx timestamp */
 #define SCAMPER_PING_REPLY_FLAG_DLRX       0x10 /* datalink rx timestamp */
+#define SCAMPER_PING_REPLY_FLAG_REPLY_TOS  0x20 /* reply tos included */
 
 #define SCAMPER_PING_METHOD_ICMP_ECHO     0x00
 #define SCAMPER_PING_METHOD_TCP_ACK       0x01
@@ -67,6 +68,7 @@ typedef struct scamper_ping_stats scamper_ping_stats_t;
 #define SCAMPER_PING_FLAG_TBT             0x80 /* -O tbt: too big trick */
 #define SCAMPER_PING_FLAG_NOSRC           0x100 /* -O nosrc: do not embed src */
 #define SCAMPER_PING_FLAG_RAW             0x200 /* -O raw: tx with raw IPv4 */
+#define SCAMPER_PING_FLAG_SOCKRX          0x400 /* -O sockrx: rx from socket */
 
 /* basic routines to use and free scamper_ping structures */
 void scamper_ping_free(scamper_ping_t *ping);
@@ -124,6 +126,7 @@ uint16_t scamper_ping_reply_probe_ipid_get(const scamper_ping_reply_t *reply);
 uint16_t scamper_ping_reply_probe_sport_get(const scamper_ping_reply_t *reply);
 uint8_t scamper_ping_reply_proto_get(const scamper_ping_reply_t *reply);
 uint8_t scamper_ping_reply_ttl_get(const scamper_ping_reply_t *reply);
+uint8_t scamper_ping_reply_tos_get(const scamper_ping_reply_t *reply);
 uint16_t scamper_ping_reply_size_get(const scamper_ping_reply_t *reply);
 uint16_t scamper_ping_reply_ipid_get(const scamper_ping_reply_t *reply);
 uint32_t scamper_ping_reply_ipid32_get(const scamper_ping_reply_t *reply);
@@ -132,6 +135,7 @@ int scamper_ping_reply_flag_is_reply_ipid(const scamper_ping_reply_t *reply);
 uint8_t scamper_ping_reply_icmp_type_get(const scamper_ping_reply_t *reply);
 uint8_t scamper_ping_reply_icmp_code_get(const scamper_ping_reply_t *reply);
 uint8_t scamper_ping_reply_tcp_flags_get(const scamper_ping_reply_t *reply);
+const char *scamper_ping_reply_ifname_get(const scamper_ping_reply_t *reply);
 int scamper_ping_reply_is_icmp(const scamper_ping_reply_t *reply);
 int scamper_ping_reply_is_tcp(const scamper_ping_reply_t *reply);
 int scamper_ping_reply_is_udp(const scamper_ping_reply_t *reply);

--- a/scamper/ping/scamper_ping_cmd.c
+++ b/scamper/ping/scamper_ping_cmd.c
@@ -1,7 +1,7 @@
 /*
  * scamper_ping_cmd.c
  *
- * $Id: scamper_ping_cmd.c,v 1.22 2024/02/29 01:43:49 mjl Exp $
+ * $Id: scamper_ping_cmd.c,v 1.25 2024/06/26 20:05:29 mjl Exp $
  *
  * Copyright (C) 2005-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -87,7 +87,7 @@ static const scamper_option_in_t opts[] = {
   {'T', NULL, PING_OPT_TIMESTAMP,    SCAMPER_OPTION_TYPE_STR},
   {'U', NULL, PING_OPT_USERID,       SCAMPER_OPTION_TYPE_NUM},
   {'W', NULL, PING_OPT_WAITTIMEOUT,  SCAMPER_OPTION_TYPE_STR},
-  {'z', NULL, PING_OPT_PROBETOS,     SCAMPER_OPTION_TYPE_NUM},
+  {'z', NULL, PING_OPT_PROBETOS,     SCAMPER_OPTION_TYPE_STR},
 };
 static const int opts_cnt = SCAMPER_OPTION_COUNT(opts);
 
@@ -251,13 +251,15 @@ static int ping_arg_param_validate(int optid, char *param, long long *out,
 	tmp = SCAMPER_PING_FLAG_NOSRC;
       else if(strcasecmp(param, "raw") == 0)
 	tmp = SCAMPER_PING_FLAG_RAW;
+      else if(strcasecmp(param, "sockrx") == 0)
+	tmp = SCAMPER_PING_FLAG_SOCKRX;
       else if(strcasecmp(param, "spoof") == 0)
 	tmp = SCAMPER_PING_FLAG_SPOOF;
       else if(strcasecmp(param, "tbt") == 0)
 	tmp = SCAMPER_PING_FLAG_TBT;
       else
 	{
-	  snprintf(errbuf, errlen, "-O %s unknown", param);
+	  snprintf(errbuf, errlen, "unknown option");
 	  goto err;
 	}
       break;
@@ -440,9 +442,8 @@ void *scamper_do_ping_alloc(char *str, char *errbuf, size_t errlen)
 	 ping_arg_param_validate(opt->id, opt->str, &tmp,
 				 buf, sizeof(buf)) != 0)
 	{
-	  snprintf(errbuf, errlen, "-%c %s failed: %s",
-		   scamper_options_id2c(opts, opts_cnt, opt->id),
-		   opt->str, buf);
+	  snprintf(errbuf, errlen, "-%c failed: %s",
+		   scamper_options_id2c(opts, opts_cnt, opt->id), buf);
 	  goto err;
 	}
 
@@ -789,6 +790,12 @@ void *scamper_do_ping_alloc(char *str, char *errbuf, size_t errlen)
 	  snprintf(errbuf, errlen, "specify valid path-mtu");
 	  goto err;
 	}
+    }
+
+  if(reply_pmtu != 0 && (flags & SCAMPER_PING_FLAG_SOCKRX) != 0)
+    {
+      snprintf(errbuf, errlen, "cannot specify -O sockrx with -M");
+      goto err;
     }
 
   if(src != NULL &&

--- a/scamper/ping/scamper_ping_do.c
+++ b/scamper/ping/scamper_ping_do.c
@@ -1,7 +1,7 @@
 /*
  * scamper_do_ping.c
  *
- * $Id: scamper_ping_do.c,v 1.182 2024/02/29 03:37:00 mjl Exp $
+ * $Id: scamper_ping_do.c,v 1.190 2024/07/11 09:50:36 mjl Exp $
  *
  * Copyright (C) 2005-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -32,6 +32,8 @@
 #include "scamper.h"
 #include "scamper_addr.h"
 #include "scamper_addr_int.h"
+#include "scamper_ifname.h"
+#include "scamper_ifname_int.h"
 #include "scamper_list.h"
 #include "scamper_ping.h"
 #include "scamper_ping_int.h"
@@ -138,7 +140,7 @@ static int ping_dltx(scamper_ping_t *ping)
 {
   if(ping->rtr != NULL || ping->reply_pmtu != 0 ||
      (SCAMPER_ADDR_TYPE_IS_IPV4(ping->dst) && scamper_osinfo_is_sunos()) ||
-     (ping->flags & SCAMPER_PING_FLAG_SPOOF) != 0)
+     SCAMPER_PING_FLAG_IS_SPOOF(ping))
     return 1;
   return 0;
 }
@@ -184,6 +186,8 @@ static uint16_t match_ipid(scamper_task_t *task, uint16_t ipid)
 
 static void do_ping_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
 {
+  static const int DIR_INBOUND  = 0;
+  static const int DIR_OUTBOUND = 1;
   scamper_ping_t       *ping  = ping_getdata(task);
   ping_state_t         *state = ping_getstate(task);
   scamper_ping_reply_t *reply = NULL;
@@ -221,9 +225,7 @@ static void do_ping_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
 	     dl->dl_icmp_id != ping->probe_sport)
 	    return;
 
-	  /* this is an inbound packet */
-	  direction = 0;
-
+	  direction = DIR_INBOUND;
 	  seq = dl->dl_icmp_seq;
 	  if(seq < ping->probe_dport)
 	    seq = seq + 0x10000;
@@ -259,9 +261,7 @@ static void do_ping_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
 	     scamper_addr_raw_cmp(ping->dst, dl->dl_ip_dst) != 0)
 	    return;
 
-	  /* this is an outbound packet */
-	  direction = 1;
-
+	  direction = DIR_OUTBOUND;
 	  seq = dl->dl_icmp_seq;
 	  if(seq < ping->probe_dport)
 	    seq = seq + 0x10000;
@@ -275,9 +275,7 @@ static void do_ping_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
 	  if(scamper_addr_raw_cmp(ping->dst, dl->dl_icmp_ip_dst) != 0)
 	    return;
 
-	  /* this is an inbound packet */
-	  direction = 0;
-
+	  direction = DIR_INBOUND;
 	  if(SCAMPER_PING_METHOD_IS_ICMP(ping))
 	    {
 	      if((SCAMPER_PING_METHOD_IS_ICMP_ECHO(ping) &&
@@ -341,6 +339,9 @@ static void do_ping_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
 	  else return;
 	}
       else return;
+
+      if(direction == DIR_INBOUND && SCAMPER_PING_FLAG_IS_SOCKRX(ping))
+	return;
     }
   else if(SCAMPER_DL_IS_TCP(dl))
     {
@@ -396,8 +397,7 @@ static void do_ping_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
 	      seq = u16;
 	    }
 
-	  /* this is an outbound packet */
-	  direction = 1;
+	  direction = DIR_OUTBOUND;
 	}
       else if(dl->dl_tcp_sport == ping->probe_dport &&
 	      scamper_addr_raw_cmp(ping->src, dl->dl_ip_dst) == 0 &&
@@ -429,8 +429,7 @@ static void do_ping_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
 	      seq = u16;
 	    }
 
-	  /* this is an inbound packet */
-	  direction = 0;
+	  direction = DIR_INBOUND;
 	}
       else return;
     }
@@ -464,8 +463,7 @@ static void do_ping_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
 	    }
 	  else return;
 
-	  /* this is an inbound packet */
-	  direction = 0;
+	  direction = DIR_INBOUND;
 	}
       else if(dl->dl_udp_sport == ping->probe_sport &&
 	      scamper_addr_raw_cmp(ping->src, dl->dl_ip_src) == 0 &&
@@ -486,8 +484,7 @@ static void do_ping_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
 	    }
 	  else return;
 
-	  /* this is an outbound packet */
-	  direction = 1;
+	  direction = DIR_OUTBOUND;
 	}
       else return;
     }
@@ -500,7 +497,7 @@ static void do_ping_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
   probe = state->probes[seq];
   assert(probe != NULL);
 
-  if(direction == 0)
+  if(direction == DIR_INBOUND)
     {
       /* allocate a reply structure for the response */
       if((reply = scamper_ping_reply_alloc()) == NULL)
@@ -552,9 +549,14 @@ static void do_ping_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
 	  reply->flags |= SCAMPER_PING_REPLY_FLAG_REPLY_IPID;
 	}
 
+      reply->reply_tos = dl->dl_ip_tos;
+      reply->flags |= SCAMPER_PING_REPLY_FLAG_REPLY_TOS;
+
+      reply->ifname = scamper_ifname_int_get(dl->dl_ifindex, &dl->dl_tv);
+
       if(ping->ping_replies[seq] == NULL)
 	{
-	  if((ping->flags & SCAMPER_PING_FLAG_TBT) == 0)
+	  if(SCAMPER_PING_FLAG_IS_TBT(ping) == 0)
 	    {
 	      /*
 	       * if this is the first reply we have for this hop, then increment
@@ -649,7 +651,7 @@ static void do_ping_handle_icmp(scamper_task_t *task, scamper_icmp_resp_t *ir)
    * do not consider ICMP responses if we're going to catch them on
    * the datalink interface
    */
-  if(state->dl != NULL)
+  if(state->dl != NULL && SCAMPER_PING_FLAG_IS_SOCKRX(ping) == 0)
     return;
 
   /* if this is an echo reply packet, then check the id and sequence */
@@ -834,6 +836,9 @@ static void do_ping_handle_icmp(scamper_task_t *task, scamper_icmp_resp_t *ir)
       reply->probe_ipid = probe->ipid;
       reply->flags |= SCAMPER_PING_REPLY_FLAG_PROBE_IPID;
 
+      reply->reply_tos = ir->ir_ip_tos;
+      reply->flags |= SCAMPER_PING_REPLY_FLAG_REPLY_TOS;
+
       reply->reply_proto = IPPROTO_ICMP;
 
       if(ips != NULL && ipc > 0)
@@ -871,6 +876,11 @@ static void do_ping_handle_icmp(scamper_task_t *task, scamper_icmp_resp_t *ir)
   else if(ir->ir_af == AF_INET6)
     {
       reply->reply_proto = IPPROTO_ICMPV6;
+      if(ir->ir_flags & SCAMPER_ICMP_RESP_FLAG_TCLASS)
+	{
+	  reply->reply_tos = ir->ir_ip_tos;
+	  reply->flags |= SCAMPER_PING_REPLY_FLAG_REPLY_TOS;
+	}
     }
 
   if(ir->ir_ip_ttl != -1)
@@ -878,6 +888,12 @@ static void do_ping_handle_icmp(scamper_task_t *task, scamper_icmp_resp_t *ir)
       reply->reply_ttl = (uint8_t)ir->ir_ip_ttl;
       reply->flags |= SCAMPER_PING_REPLY_FLAG_REPLY_TTL;
     }
+
+  if(ir->ir_flags & SCAMPER_ICMP_RESP_FLAG_IFINDEX)
+    reply->ifname = scamper_ifname_int_get(ir->ir_ifindex, &ir->ir_rx);
+
+  if(probe->dlts != 0)
+    reply->flags |= SCAMPER_PING_REPLY_FLAG_DLTX;
 
   /*
    * if this is the first reply we have for this hop, then increment
@@ -1069,20 +1085,20 @@ static int ping_state_payload(scamper_ping_t *ping, ping_state_t *state)
   char errbuf[256];
 
   /* payload to send in the probe */
-  if(ping->dst->type == SCAMPER_ADDR_TYPE_IPV4)
+  if(SCAMPER_ADDR_TYPE_IS_IPV4(ping->dst))
     {
       al = 4;
       hdr = 20;
-      if((ping->flags & SCAMPER_PING_FLAG_V4RR) != 0)
+      if(SCAMPER_PING_FLAG_IS_V4RR(ping))
 	hdr += 40;
-      else if((ping->flags & SCAMPER_PING_FLAG_TSONLY) != 0)
+      else if(SCAMPER_PING_FLAG_IS_TSONLY(ping))
 	hdr += 40;
-      else if((ping->flags & SCAMPER_PING_FLAG_TSANDADDR) != 0)
+      else if(SCAMPER_PING_FLAG_IS_TSANDADDR(ping))
 	hdr += 36;
       else if(state->tsps_ipc > 0)
 	hdr += (state->tsps_ipc * 4 * 2) + 4;
     }
-  else if(ping->dst->type == SCAMPER_ADDR_TYPE_IPV6)
+  else if(SCAMPER_ADDR_TYPE_IS_IPV6(ping->dst))
     {
       al = 16;
       hdr = 40;
@@ -1118,8 +1134,8 @@ static int ping_state_payload(scamper_ping_t *ping, ping_state_t *state)
       off += 12;
     }
 
-  if((ping->flags & SCAMPER_PING_FLAG_SPOOF) != 0 &&
-     (ping->flags & SCAMPER_PING_FLAG_NOSRC) == 0 &&
+  if(SCAMPER_PING_FLAG_IS_SPOOF(ping) &&
+     SCAMPER_PING_FLAG_IS_NOSRC(ping) == 0 &&
      ping->probe_method != SCAMPER_PING_METHOD_TCP_SYNACK &&
      ping->probe_method != SCAMPER_PING_METHOD_TCP_RST)
     {
@@ -1133,7 +1149,7 @@ static int ping_state_payload(scamper_ping_t *ping, ping_state_t *state)
     }
 
   /* need scratch space in the probe to help fudge icmp checksum */
-  if((ping->flags & SCAMPER_PING_FLAG_ICMPSUM) != 0)
+  if(SCAMPER_PING_FLAG_IS_ICMPSUM(ping))
     {
       assert(state->payload_len >= off + 2);
       state->payload[off++] = 0;
@@ -1142,7 +1158,7 @@ static int ping_state_payload(scamper_ping_t *ping, ping_state_t *state)
 
   if(ping->probe_data != NULL)
     {
-      if((ping->flags & SCAMPER_PING_FLAG_PAYLOAD) != 0)
+      if(SCAMPER_PING_FLAG_IS_PAYLOAD(ping))
 	{
 	  assert(state->payload_len >= off + ping->probe_datalen);
 	  memcpy(state->payload+off, ping->probe_data, ping->probe_datalen);
@@ -1238,7 +1254,7 @@ static int ping_state_alloc(scamper_task_t *task)
     for(i=0; i<ping->probe_tsps->ipc; i++)
       memcpy(&state->tsps_ips[i], ping->probe_tsps->ips[i]->addr, 4);
 
-  if((ping->flags & SCAMPER_PING_FLAG_DL) != 0 ||
+  if(SCAMPER_PING_FLAG_IS_DL(ping) ||
      SCAMPER_PING_METHOD_IS_TCP(ping) ||
      ping_dltx(ping))
     {
@@ -1253,7 +1269,7 @@ static int ping_state_alloc(scamper_task_t *task)
       state->mode = MODE_PING;
     }
 
-  if((ping->flags & SCAMPER_PING_FLAG_SPOOF) == 0)
+  if(SCAMPER_PING_FLAG_IS_SPOOF(ping) == 0)
     {
       if(SCAMPER_ADDR_TYPE_IS_IPV4(ping->dst))
 	state->icmp = scamper_fd_icmp4(ping->src->addr);
@@ -1268,7 +1284,7 @@ static int ping_state_alloc(scamper_task_t *task)
     {
       state->raw = scamper_fd_udp4raw(ping->src->addr);
     }
-  else if((ping->flags & SCAMPER_PING_FLAG_RAW) != 0)
+  else if(SCAMPER_PING_FLAG_IS_RAW(ping))
     {
       /* probe using a raw TCP socket */
       state->raw = scamper_fd_ip4();
@@ -1354,8 +1370,7 @@ static void do_ping_probe(scamper_task_t *task)
       ping_dltx(ping)))
     {
       probe.pr_dl     = scamper_fd_dl_get(state->dl);
-      probe.pr_dl_buf = state->dlhdr->buf;
-      probe.pr_dl_len = state->dlhdr->len;
+      probe.pr_dlhdr  = state->dlhdr;
     }
 
   if(state->ptb != 0)
@@ -1402,19 +1417,19 @@ static void do_ping_probe(scamper_task_t *task)
   if(ping->dst->type == SCAMPER_ADDR_TYPE_IPV4)
     probe.pr_ip_off  = IP_DF;
 
-  if((ping->flags & SCAMPER_PING_FLAG_V4RR) != 0)
+  if(SCAMPER_PING_FLAG_IS_V4RR(ping))
     {
       opt.type = SCAMPER_PROBE_IPOPTS_V4RR;
       probe.pr_ipopts = &opt;
       probe.pr_ipoptc = 1;
     }
-  else if((ping->flags & SCAMPER_PING_FLAG_TSONLY) != 0)
+  else if(SCAMPER_PING_FLAG_IS_TSONLY(ping))
     {
       opt.type = SCAMPER_PROBE_IPOPTS_V4TSO;
       probe.pr_ipopts = &opt;
       probe.pr_ipoptc = 1;
     }
-  else if((ping->flags & SCAMPER_PING_FLAG_TSANDADDR) != 0)
+  else if(SCAMPER_PING_FLAG_IS_TSANDADDR(ping))
     {
       opt.type = SCAMPER_PROBE_IPOPTS_V4TSAA;
       probe.pr_ipopts = &opt;
@@ -1448,10 +1463,10 @@ static void do_ping_probe(scamper_task_t *task)
 	  i += 12;
 	}
 
-      if((ping->flags & SCAMPER_PING_FLAG_ICMPSUM) != 0)
+      if(SCAMPER_PING_FLAG_IS_ICMPSUM(ping))
 	{
 	  probe.pr_icmp_sum = u16 = htons(ping->probe_icmpsum);
-	  if((ping->flags & SCAMPER_PING_FLAG_SPOOF) != 0)
+	  if(SCAMPER_PING_FLAG_IS_SPOOF(ping))
 	    i += 4;
 	  memcpy(state->payload+i, &u16, 2);
 	  if(SCAMPER_ADDR_TYPE_IS_IPV4(ping->dst))
@@ -1600,7 +1615,7 @@ scamper_task_t *scamper_do_ping_alloctask(void *data, scamper_list_t *list,
   if(ping->src == NULL &&
      (ping->src = scamper_getsrc(ping->dst, 0, errbuf, errlen)) == NULL)
     goto err;
-  if((ping->flags & SCAMPER_PING_FLAG_SPOOF) == 0)
+  if(SCAMPER_PING_FLAG_IS_SPOOF(ping) == 0)
     sig->sig_tx_ip_src = scamper_addr_use(ping->src);
 
   /* allocate a file descriptor for each source port needed */
@@ -1620,7 +1635,7 @@ scamper_task_t *scamper_do_ping_alloctask(void *data, scamper_list_t *list,
    * no need to open a probe socket if we're going to spoof, as we'll
    * be using a datalink interface
    */
-  if((ping->flags & SCAMPER_PING_FLAG_SPOOF) != 0)
+  if(SCAMPER_PING_FLAG_IS_SPOOF(ping))
     goto install;
 
   if(SCAMPER_PING_METHOD_IS_TCP(ping))
@@ -1747,7 +1762,7 @@ scamper_task_t *scamper_do_ping_alloctask(void *data, scamper_list_t *list,
 	  goto err;
 	}
       sig->sig_tx_ip_dst = scamper_addr_use(ping->dst);
-      if((ping->flags & SCAMPER_PING_FLAG_SPOOF) == 0)
+      if(SCAMPER_PING_FLAG_IS_SPOOF(ping) == 0)
 	sig->sig_tx_ip_src = scamper_addr_use(ping->src);
 
       if(SCAMPER_ADDR_TYPE_IS_IPV4(ping->dst))

--- a/scamper/ping/scamper_ping_int.h
+++ b/scamper/ping/scamper_ping_int.h
@@ -1,7 +1,7 @@
 /*
  * scamper_ping_int.h
  *
- * $Id: scamper_ping_int.h,v 1.8 2024/02/27 01:07:22 mjl Exp $
+ * $Id: scamper_ping_int.h,v 1.12 2024/06/26 20:05:29 mjl Exp $
  *
  * Copyright (C) 2005-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -125,6 +125,39 @@ uint32_t scamper_ping_reply_total(const scamper_ping_t *ping);
   (SCAMPER_PING_REPLY_IS_ICMP_UNREACH_PORT(reply) ||  \
    SCAMPER_PING_REPLY_IS_UDP(reply))))
 
+#define SCAMPER_PING_FLAG_IS_V4RR(ping) (	\
+ ((ping)->flags & SCAMPER_PING_FLAG_V4RR))
+
+#define SCAMPER_PING_FLAG_IS_SPOOF(ping) (	\
+ ((ping)->flags & SCAMPER_PING_FLAG_SPOOF))
+
+#define SCAMPER_PING_FLAG_IS_PAYLOAD(ping) (	\
+ ((ping)->flags & SCAMPER_PING_FLAG_PAYLOAD))
+
+#define SCAMPER_PING_FLAG_IS_TSONLY(ping) (	\
+ ((ping)->flags & SCAMPER_PING_FLAG_TSONLY))
+
+#define SCAMPER_PING_FLAG_IS_TSANDADDR(ping) (	\
+ ((ping)->flags & SCAMPER_PING_FLAG_TSANDADDR))
+
+#define SCAMPER_PING_FLAG_IS_ICMPSUM(ping) (	\
+ ((ping)->flags & SCAMPER_PING_FLAG_ICMPSUM))
+
+#define SCAMPER_PING_FLAG_IS_DL(ping) (		\
+ ((ping)->flags & SCAMPER_PING_FLAG_DL))
+
+#define SCAMPER_PING_FLAG_IS_TBT(ping) (	\
+ ((ping)->flags & SCAMPER_PING_FLAG_TBT))
+
+#define SCAMPER_PING_FLAG_IS_NOSRC(ping) (	\
+ ((ping)->flags & SCAMPER_PING_FLAG_NOSRC))
+
+#define SCAMPER_PING_FLAG_IS_RAW(ping) (	\
+ ((ping)->flags & SCAMPER_PING_FLAG_RAW))
+
+#define SCAMPER_PING_FLAG_IS_SOCKRX(ping) (	\
+ ((ping)->flags & SCAMPER_PING_FLAG_SOCKRX))
+
 struct scamper_ping_stats
 {
   uint32_t nreplies;
@@ -136,6 +169,8 @@ struct scamper_ping_stats
   struct timeval avg_rtt;
   struct timeval stddev_rtt;
 };
+
+struct scamper_ifname;
 
 /*
  * scamper_ping_reply_v4rr
@@ -206,6 +241,7 @@ struct scamper_ping_reply
   uint16_t                   probe_sport;
   uint8_t                    reply_proto;
   uint8_t                    reply_ttl;
+  uint8_t                    reply_tos;
   uint16_t                   reply_size;
   uint16_t                   reply_ipid;
   uint32_t                   reply_ipid32;
@@ -223,6 +259,9 @@ struct scamper_ping_reply
   /* the time elapsed between sending the probe and getting this response */
   struct timeval             tx;
   struct timeval             rtt;
+
+  /* the name of the interface that received the response */
+  struct scamper_ifname     *ifname;
 
   /* data found in IP options, if any */
   scamper_ping_reply_v4rr_t *v4rr;

--- a/scamper/ping/scamper_ping_lib.c
+++ b/scamper/ping/scamper_ping_lib.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2023 Matthew Luckie
  * Author: Matthew Luckie
  *
- * $Id: scamper_ping_lib.c,v 1.8 2024/02/28 23:35:23 mjl Exp $
+ * $Id: scamper_ping_lib.c,v 1.10 2024/05/01 07:46:20 mjl Exp $
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,6 +31,8 @@
 #include "scamper_addr_int.h"
 #include "scamper_ping.h"
 #include "scamper_ping_int.h"
+#include "scamper_ifname.h"
+#include "scamper_ifname_int.h"
 
 scamper_list_t *scamper_ping_list_get(const scamper_ping_t *ping)
 {
@@ -247,6 +249,11 @@ uint8_t scamper_ping_reply_ttl_get(const scamper_ping_reply_t *reply)
   return reply->reply_ttl;
 }
 
+uint8_t scamper_ping_reply_tos_get(const scamper_ping_reply_t *reply)
+{
+  return reply->reply_tos;
+}
+
 uint16_t scamper_ping_reply_size_get(const scamper_ping_reply_t *reply)
 {
   return reply->reply_size;
@@ -287,6 +294,13 @@ uint8_t scamper_ping_reply_icmp_code_get(const scamper_ping_reply_t *reply)
 uint8_t scamper_ping_reply_tcp_flags_get(const scamper_ping_reply_t *reply)
 {
   return reply->tcp_flags;
+}
+
+const char *scamper_ping_reply_ifname_get(const scamper_ping_reply_t *reply)
+{
+  if(reply->ifname == NULL)
+    return NULL;
+  return reply->ifname->ifname;
 }
 
 int scamper_ping_reply_is_icmp(const scamper_ping_reply_t *reply)

--- a/scamper/scamper.1
+++ b/scamper/scamper.1
@@ -10,12 +10,9 @@
 .\" Copyright (c) 2024      The Regents of the University of California
 .\"                         All rights reserved
 .\"
-.\" $Id: scamper.1,v 1.131 2024/02/29 01:48:36 mjl Exp $
+.\" $Id: scamper.1,v 1.140 2024/07/15 23:12:44 mjl Exp $
 .\"
-.\"  nroff -man scamper.1
-.\"  groff -man -Tascii scamper.1 | man2html -title scamper.1
-.\"
-.Dd February 29, 2024
+.Dd July 16, 2024
 .Dt SCAMPER 1
 .Os
 .\""""""""""""
@@ -50,8 +47,8 @@ to IPv4 and IPv6 addresses, in parallel, to fill a specified
 packets-per-second rate.  Currently,
 .Nm
 supports the well-known traceroute and ping techniques, DNS,
-as well as MDA traceroute, alias resolution, some parts of tbit, sting,
-and neighbour discovery.
+as well as MDA traceroute, six different alias resolution techniques,
+most tbit methods, sting, neighbour discovery, HTTP(S), and UDP probes.
 .Pp
 .Nm
 has five modes of operation.
@@ -304,6 +301,22 @@ accuracy on Linux systems with other non-scamper traffic. See
 .Xr packet 7
 for further details.
 .It
+.Sy dl-any:
+tell scamper to use a single socket to receive datalink responses on
+Linux.  This prevents datalink transmission at this time.  See
+.Xr packet 7
+for further details.
+.It
+.Sy dyn-filter:
+tell scamper to use dynamic BPF filters to filter datalink responses
+in the kernel, rather than a static BPF filter that passes all traffic
+through.  This facility is available on Linux, and BSD systems with
+BIOCSETFNR available, such as MacOS and FreeBSD. See
+.Xr packet 7
+or
+.Xr bpf 4
+for further details.
+.It
 .Sy cmdfile:
 the input file consists of complete commands.
 .It
@@ -385,6 +398,7 @@ trace
 .Op Fl f Ar firsthop
 .Op Fl g Ar gaplimit
 .Op Fl G Ar gapaction
+.Op Fl H Ar wait-probe-hop
 .Op Fl l Ar loops
 .Op Fl m Ar maxttl
 .Op Fl N Ar squeries
@@ -424,6 +438,11 @@ not recommended.
 specifies what should happen if the gaplimit condition is met.  A value of
 1 (default) means halt probing, while a value of 2 means send last-ditch
 probes.
+.It Fl H Ar wait-probe-hop
+specifies the minimum time to wait, in seconds, between sending
+consecutive probes that use the same TTL value.  By default, the next
+probe is sent as soon as possible after receiving a response to a probe
+with a given TTL value.  The limit is 2 seconds.
 .It Fl l Ar loops
 specifies the maximum number of loops permitted until probing stops.  By
 default, a value of one is used.  A value of zero disables loop checking.
@@ -615,6 +634,10 @@ the payload of the packet when the spoof option is used.
 .It
 .Sy raw:
 send IPv4 TCP probes using a raw socket, rather than a datalink interface.
+.It
+.Sy sockrx:
+specifies that responses should be collected from a socket, rather than
+from a datalink interface.
 .It
 .Sy spoof:
 specifies that the source address is to be spoofed according to the address
@@ -885,18 +908,15 @@ tbit command:
 .Pp
 tbit
 .\"tbit [-t type] [-p app] [-d dport] [-s sport] [-b asn] [-f cookie]\n"
-.\"     [-i icw] [-L abclimit] [-m mss] [-M mtu] [-o offset] [-O option]\n"
+.\"     [-m mss] [-M mtu] [-o offset] [-O option] [-U userid] [-w wscale]\n"
 .\"     [-P ptbsrc] [-q attempts] [-S srcaddr] [-T ttl] [-u url]";
 .Bk -words
 .Op Fl t Ar type
 .Op Fl p Ar app
 .Op Fl d Ar dport
 .Op Fl s Ar sport
-.Op Fl a Ar acks
 .Op Fl b Ar ASN
-.Op Fl i Ar ICW
 .Op Fl f Ar cookie
-.Op Fl L Ar limit
 .Op Fl m Ar mss
 .Op Fl M Ar mtu
 .Op Fl o Ar offset
@@ -912,8 +932,8 @@ tbit
 .Bl -tag -width Es
 .It Fl t Ar type
 specifies which type of testing to use.
-Valid options are: pmtud, ecn, null, sack-rcvr, icw, abc, blind-rst,
-blind-syn, blind-data.
+Valid options are: pmtud, ecn, null, sack-rcvr, icw, blind-rst,
+blind-syn, blind-data, blind-fin.
 .It Fl p Ar app
 specifies what kind of traffic to generate for testing.
 Destination port defaults the application standard port.
@@ -926,20 +946,12 @@ specifies the source port for the packets being sent.
 By default,
 .Nm
 uses a value it derives from the process ID.
-.It Fl a Ar acks
-specifies the sequence of packets that should be acknowledged as part of
-the ABC test.
 .It Fl b Ar ASN
 specifies the autonomous system number (ASN) that should be used when
 establishing a BGP session.
-.It Fl i Ar ICW
-specifies the initial congestion window (ICW) that we expect from the peer
-when conducting the ABC test.
 .It Fl f Ar cookie
 specifies the TCP fast open cookie that should be used when establishing
 a TCP connection.
-.It Fl L Ar limit
-test the response to a theoretical limit (L) value with ABC.
 .It Fl m Ar mss
 specifies the maximum segment size to advertise to the remote host.
 .It Fl M Ar mtu
@@ -1170,8 +1182,12 @@ sting
 .Bl -tag -width Es
 .It Fl c Ar limit-pktc
 specifies the maximum number of packets to capture.
+By default, sniff will return after it has captured 100 packets;
+the maximum value is 5000 packets.
 .It Fl G Ar limit-time
 specifies the maximum time, in seconds, to capture packets.
+By default, sniff will return after it has listened for 60 seconds;
+the limit is 20 minutes.
 .It Fl S Ar ipaddr
 specifies the IP address that packets must arrive using.
 scamper uses the IP address to identify the appropriate interface
@@ -1520,19 +1536,6 @@ The
 .Ic outfile list
 command outputs a list of the existing outfiles.
 .El
-.It Ic observe sources
-This command allows for monitoring of source events.
-When executed, the control socket will then supply event notices
-whenever a source is added, updated, deleted, finished, or cycled.
-Each event is prefixed with a count of the number of seconds elapsed since
-the Unix epoch.
-The following examples illustrate the event monitoring capabilities:
-.Pp
-.Dl EVENT 1169065640 source add name 'foo' list_id 5 priority 1
-.Dl EVENT 1169065641 source update 'foo' priority 15
-.Dl EVENT 1169065642 source cycle 'bar' id 2
-.Dl EVENT 1169065650 source finish 'bar'
-.Dl EVENT 1169065661 source delete 'foo'
 .It Ic shutdown Ar argument
 The shutdown argument allows the
 .Nm
@@ -1686,6 +1689,7 @@ scamper -R foo.example.com:31337 -O cafile=/etc/ssl/certs/ca-certificates.crt
 .Sh SEE ALSO
 .Xr ping 8 ,
 .Xr traceroute 8 ,
+.Xr libscamperctrl 3 ,
 .Xr libscamperfile 3 ,
 .Xr sc_ally 1 ,
 .Xr sc_analysis_dump 1 ,
@@ -1826,7 +1830,8 @@ scamper -R foo.example.com:31337 -O cafile=/etc/ssl/certs/ca-certificates.crt
 .Sh AUTHORS
 .Nm
 was written by Matthew Luckie <mjl@luckie.org.nz>.
-Alistair King contributed an initial implementation of Doubletree;
+Alistair King contributed an initial implementation of Doubletree and
+support for memory-mapped ring buffers on Linux;
 Ben Stasiewicz contributed an initial implementation of TBIT's PMTUD test;
 Stephen Eichler contributed an initial implementation of TBIT's ECN test;
 Boris Pfahringer adapted

--- a/scamper/scamper.h
+++ b/scamper/scamper.h
@@ -1,7 +1,7 @@
 /*
  * scamper.h
  *
- * $Id: scamper.h,v 1.73.2.1 2024/02/29 03:56:38 mjl Exp $
+ * $Id: scamper.h,v 1.77.2.1 2024/07/16 01:11:34 mjl Exp $
  *
  * Copyright (C) 2003-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -67,11 +67,16 @@ unsigned int scamper_option_ring_blocks(void);
 unsigned int scamper_option_ring_block_size(void);
 int scamper_option_ring_locked(void);
 
+int scamper_option_dlany(void);
+int scamper_option_dynfilter(void);
+
 void scamper_exitwhendone(int on);
 
 #ifdef HAVE_SETEUID
 uid_t scamper_getuid(void);
 uid_t scamper_geteuid(void);
+int scamper_seteuid_raise(uid_t *uid, uid_t *euid);
+void scamper_seteuid_lower(uid_t *uid, uid_t *euid);
 #endif
 
 int scamper_pidfile(void);
@@ -79,6 +84,6 @@ int scamper_pidfile(void);
 uint16_t scamper_sport_default(void);
 uint16_t scamper_pid_u16(void);
 
-#define SCAMPER_VERSION "20240229"
+#define SCAMPER_VERSION "20240716"
 
 #endif /* __SCAMPER_H */

--- a/scamper/scamper_control.c
+++ b/scamper/scamper_control.c
@@ -1,7 +1,7 @@
 /*
  * scamper_control.c
  *
- * $Id: scamper_control.c,v 1.266 2024/02/12 20:35:36 mjl Exp $
+ * $Id: scamper_control.c,v 1.271 2024/06/25 06:03:55 mjl Exp $
  *
  * Copyright (C) 2004-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -192,9 +192,6 @@ typedef struct client
 
   /* node for this client in the list of connected clients */
   dlist_node_t       *node;
-
-  /* pointer returned by the source observe code */
-  void               *observe;
 
   /* linepoll to process incoming lines of text */
   scamper_linepoll_t *lp;
@@ -444,7 +441,7 @@ static char *client_sockaddr_tostr(client_t *client, char *buf, size_t len)
    * get the name of the connected socket, which is used to name the
    * source and the outfile
    */
-  if(sockaddr_tostr(client->un.sock.sa, buf, len) == NULL)
+  if(sockaddr_tostr(client->un.sock.sa, buf, len, 1) == NULL)
     {
       printerror_msg(__func__, "could not decipher client sockaddr");
       return NULL;
@@ -513,13 +510,6 @@ static void client_free(client_t *client)
     {
       dlist_node_pop(client_list, client->node);
       client->node = NULL;
-    }
-
-  /* if we are monitoring source events, unobserve */
-  if(client->observe != NULL)
-    {
-      scamper_sources_unobserve(client->observe);
-      client->observe = NULL;
     }
 
   /* make sure the source is empty before freeing */
@@ -1154,133 +1144,6 @@ static int command_help(client_t *client, char *buf)
   return 0;
 }
 
-static void observe_source_event_add(const scamper_source_event_t *sse,
-				     char *buf, const size_t len)
-{
-  buf[0] = 'a'; buf[1] = 'd'; buf[2] = 'd'; buf[3] = ' ';
-  source_tostr(buf+4, len-4, sse->source);
-  return;
-}
-
-static void observe_source_event_update(const scamper_source_event_t *sse,
-					char *buf, const size_t len)
-{
-  char autoreload[16];
-  char cycles[16];
-  char priority[24];
-
-  /* autoreload */
-  if(sse->sse_update_flags & 0x01)
-    snprintf(autoreload, sizeof(autoreload),
-	     " autoreload %d", sse->sse_update_autoreload);
-  else autoreload[0] = '\0';
-
-  /* cycles */
-  if(sse->sse_update_flags & 0x02)
-    snprintf(cycles, sizeof(cycles),
-	     " cycles %d", sse->sse_update_cycles);
-  else cycles[0] = '\0';
-
-  /* priority */
-  if(sse->sse_update_flags & 0x04)
-    snprintf(priority, sizeof(priority),
-	     " priority %d", sse->sse_update_priority);
-  else priority[0] = '\0';
-
-  snprintf(buf, len, "update '%s'%s%s%s",
-	   scamper_source_getname(sse->source),
-	   autoreload, cycles, priority);
-  return;
-}
-
-static void observe_source_event_cycle(const scamper_source_event_t *sse,
-				       char *buf, const size_t len)
-{
-  snprintf(buf, len, "cycle '%s' id %d",
-	   scamper_source_getname(sse->source),
-	   sse->sse_cycle_cycle_id);
-  return;
-}
-
-static void observe_source_event_delete(const scamper_source_event_t *sse,
-					char *buf, const size_t len)
-{
-  snprintf(buf, len, "delete '%s'",
-	   scamper_source_getname(sse->source));
-  return;
-}
-
-static void observe_source_event_finish(const scamper_source_event_t *sse,
-					char *buf, const size_t len)
-{
-  snprintf(buf, len, "finish '%s'",
-	   scamper_source_getname(sse->source));
-  return;
-}
-
-/*
- * command_observe_source_cb
- *
- * this function is a callback that is used whenever some event occurs
- * with a source.
- */
-static void command_observe_source_cb(const scamper_source_event_t *sse,
-				      void *param)
-{
-  static void (* const func[])(const scamper_source_event_t *,
-			       char *, const size_t) =
-  {
-    observe_source_event_add,
-    observe_source_event_update,
-    observe_source_event_cycle,
-    observe_source_event_delete,
-    observe_source_event_finish,
-  };
-  client_t *client = (client_t *)param;
-  char buf[512];
-  size_t len;
-
-  if(sse->event < 0x01 || sse->event > 0x05)
-    {
-      return;
-    }
-
-  snprintf(buf, sizeof(buf), "EVENT %u source ", (uint32_t)sse->sec);
-  len = strlen(buf);
-
-  func[sse->event-1](sse, buf + len, sizeof(buf)-len);
-  client_send(client, "%s", buf);
-
-  return;
-}
-
-static int command_observe(client_t *client, char *buf)
-{
-  if(buf == NULL)
-    {
-      client_send(client, "ERR usage: observe [sources]");
-      return 0;
-    }
-  string_nextword(buf);
-
-  if(strcasecmp(buf, "sources") != 0)
-    {
-      client_send(client, "ERR usage: observe [sources]");
-      return 0;
-    }
-
-  client->observe = scamper_sources_observe(command_observe_source_cb, client);
-  if(client->observe == NULL)
-    {
-      printerror(__func__, "could not observe sources");
-      client_send(client, "ERR could not observe");
-      return -1;
-    }
-
-  client_send(client, "OK");
-  return 0;
-}
-
 /*
  * command_outfile_close
  *
@@ -1766,7 +1629,7 @@ static int command_set_nameserver(client_t *client, char *buf)
 #else
   client_send(client, "ERR scamper not built with host support");
   return -1;
-#endif  
+#endif
 }
 
 static int command_set_pps(client_t *client, char *buf)
@@ -2432,7 +2295,6 @@ static int client_interactive_cb(client_t *client, uint8_t *buf, size_t len)
     {"get",        command_get},
     {"help",       command_help},
     {"lss-clear",  command_lss_clear},
-    {"observe",    command_observe},
     {"outfile",    command_outfile},
     {"remote",     command_remote},
     {"set",        command_set},
@@ -2534,7 +2396,7 @@ static void client_read(const int fd, client_t *client)
       client_free(client);
       return;
     }
-  
+
   /* handle disconnection */
   if(rrc == 0)
     {
@@ -2596,7 +2458,7 @@ static int client_write_do(client_t *client,
 	    len = snprintf(str, sizeof(str), "DATA %d id-%u\n", (int)x, o->id);
 	  else
 	    len = snprintf(str, sizeof(str), "DATA %d\n", (int)x);
-	  
+
 	  if(sendfunc(client, str, len) < 0)
 	    {
 	      printerror(__func__, "could not send DATA header");
@@ -3201,7 +3063,7 @@ static int remote_read_control_channel_new(control_remote_t *rm,
   channel = bytes_ntohl(buf);
 
   snprintf(listname,sizeof(listname), "%s_%u", rm->alias, rm->num++);
-  
+
   if((client = client_alloc(CLIENT_TYPE_CHANNEL)) == NULL ||
      (client->sof_objs = slist_alloc()) == NULL ||
      (client->sof = scamper_outfile_opennull(listname, "warts")) == NULL)
@@ -3538,8 +3400,8 @@ static int remote_send_master(control_remote_t *rm)
       off = 0;
       while(monitorname[off] != '\0')
 	{
-	  if(isalnum(monitorname[off]) == 0 &&
-	     monitorname[off] != '.' && monitorname[off] != '-')
+	  if(monitorname[off] != '.' && monitorname[off] != '-' &&
+	     isalnum((unsigned char)monitorname[off]) == 0)
 	    {
 	      printerror_msg(__func__, "monitorname contains invalid char");
 	      return -1;
@@ -3715,7 +3577,7 @@ static void remote_read(SOCKET fd, void *param)
 #endif
 
   assert(scamper_fd_fd_get(rm->fd) == fd);
-  
+
   if((rc = remote_read_sock(rm)) < 0)
     goto retry;
 
@@ -3756,7 +3618,7 @@ static int client_channel_send(client_t *client, void *buf, size_t len)
   assert(client->type == CLIENT_TYPE_CHANNEL);
   if(remote_sock_send(client->un.chan.rem, buf, len, client->un.chan.id, 1) < 0)
     return -1;
-  return 0;  
+  return 0;
 }
 
 #ifndef _WIN32 /* SOCKET vs int on windows */
@@ -3846,15 +3708,13 @@ static int remote_socket(control_remote_t *rm, int fd)
 static int remote_socket(control_remote_t *rm, SOCKET fd)
 #endif
 {
-  int opt = 1;
-
   if((rm->wb = scamper_writebuf_alloc()) == NULL)
     {
       printerror(__func__, "could not alloc wb");
       goto err;
     }
 
-  if(setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (void *)&opt, sizeof(opt)) != 0)
+  if(setsockopt_int(fd, IPPROTO_TCP, TCP_NODELAY, 1) != 0)
     {
       printerror(__func__, "could not set TCP_NODELAY");
       goto err;
@@ -4202,7 +4062,7 @@ int scamper_control_add_inet(const char *ip, int port)
   struct sockaddr_storage sas;
   struct sockaddr *sa = (struct sockaddr *)&sas;
   struct in_addr in;
-  int af = AF_INET, opt;
+  int af = AF_INET;
 
 #ifndef _WIN32 /* SOCKET vs int on windows */
   int fd = -1;
@@ -4226,7 +4086,7 @@ int scamper_control_add_inet(const char *ip, int port)
       in.s_addr = htonl(INADDR_LOOPBACK);
       sockaddr_compose(sa, AF_INET, &in, port);
     }
-  
+
   /* open the TCP socket we are going to listen on */
   fd = socket(af, SOCK_STREAM, IPPROTO_TCP);
   if(socket_isinvalid(fd))
@@ -4235,15 +4095,13 @@ int scamper_control_add_inet(const char *ip, int port)
       goto err;
     }
 
-  opt = 1;
-  if(setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (void *)&opt, sizeof(opt)) != 0)
+  if(setsockopt_int(fd, SOL_SOCKET, SO_REUSEADDR, 1) != 0)
     {
       printerror(__func__, "could not set SO_REUSEADDR");
       goto err;
     }
 
-  opt = 1;
-  if(setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (void *)&opt, sizeof(opt)) != 0)
+  if(setsockopt_int(fd, IPPROTO_TCP, TCP_NODELAY, 1) != 0)
     {
       printerror(__func__, "could not set TCP_NODELAY");
       goto err;

--- a/scamper/scamper_debug.c
+++ b/scamper/scamper_debug.c
@@ -1,7 +1,7 @@
 /*
  * scamper_debug.c
  *
- * $Id: scamper_debug.c,v 1.46 2023/08/24 04:18:44 mjl Exp $
+ * $Id: scamper_debug.c,v 1.47 2024/03/04 19:36:41 mjl Exp $
  *
  * routines to reduce the impact of debugging cruft in scamper's code.
  *
@@ -210,7 +210,7 @@ void printerror_ssl(const char *func, const char *format, ...)
       string_concat(sslbuf, sizeof(sslbuf), &off, "%s%s",
 		    off > 0 ? " " : "", buf);
     }
-  
+
   if(isdaemon == 0)
     {
       fprintf(stderr, "%s %s: %s: %s\n", ts, func, msg, sslbuf);

--- a/scamper/scamper_dl.c
+++ b/scamper/scamper_dl.c
@@ -1,7 +1,7 @@
 /*
  * scamper_dl: manage BPF/PF_PACKET datalink instances for scamper
  *
- * $Id: scamper_dl.c,v 1.201 2024/02/28 02:11:53 mjl Exp $
+ * $Id: scamper_dl.c,v 1.216 2024/07/16 00:42:55 mjl Exp $
  *
  *          Matthew Luckie
  *          Ben Stasiewicz added fragmentation support.
@@ -19,7 +19,7 @@
  * Copyright (C) 2012      Matthew Luckie
  * Copyright (C) 2014-2015 The Regents of the University of California
  * Copyright (C) 2022-2023 Matthew Luckie
- * Copyright (C) 2023      The Regents of the University of California
+ * Copyright (C) 2023-2024 The Regents of the University of California
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -94,6 +94,9 @@ struct scamper_dl
   /* the callback used to read packets off the datalink */
   int          (*dlt_cb)(scamper_dl_rec_t *dl, uint8_t *pkt, size_t len);
 
+  /* the ifindex found in the corresponding scamper_fd_t */
+  int            ifindex;
+
   /* the underlying type of the datalink (DLT_* or ARPHDR_* values) */
   int            type;
 
@@ -111,12 +114,15 @@ struct scamper_dl
 
 };
 
-#ifndef TEST_DL_PARSE_IP
+#ifdef BUILDING_SCAMPER
 static uint8_t          *readbuf = NULL;
 static size_t            readbuf_len = 0;
+#ifdef __linux__
+static int               lo_ifindex = -1;
 #endif
+#endif /* BUILDING_SCAMPER */
 
-#if defined(HAVE_BPF) && !defined(TEST_DL_PARSE_IP)
+#if defined(BUILDING_SCAMPER) && defined(HAVE_BPF)
 static const scamper_osinfo_t *osinfo = NULL;
 #endif
 
@@ -126,6 +132,7 @@ static const scamper_osinfo_t *osinfo = NULL;
  * pkt points to the beginning of an IP header.  given the length of the
  * packet, parse the contents into a datalink record structure.
  */
+#if defined(BUILDING_SCAMPER) || defined(TEST_DL_PARSE_IP)
 #ifdef TEST_DL_PARSE_IP
 int dl_parse_ip(scamper_dl_rec_t *dl, uint8_t *pktbuf, size_t pktlen)
 #else
@@ -149,6 +156,10 @@ static int dl_parse_ip(scamper_dl_rec_t *dl, uint8_t *pktbuf, size_t pktlen)
   uint16_t          u16;
   int               i;
 
+  /* minimum size of an IPv4 header, which is larger than an IPv6 header */
+  if(pktlen < 20)
+    return 0;
+
   if((pkt[0] >> 4) == 4) /* IPv4 */
     {
       ip4 = (struct ip *)pkt;
@@ -165,6 +176,8 @@ static int dl_parse_ip(scamper_dl_rec_t *dl, uint8_t *pktbuf, size_t pktlen)
        */
       if(iplen > len)
 	return 0;
+
+      memset(dl, 0, sizeof(scamper_dl_rec_t));
 
       /* figure out fragmentation details */
       u16 = ntohs(ip4->ip_off);
@@ -186,7 +199,7 @@ static int dl_parse_ip(scamper_dl_rec_t *dl, uint8_t *pktbuf, size_t pktlen)
       dl->dl_ip_src   = (uint8_t *)&ip4->ip_src;
       dl->dl_ip_dst   = (uint8_t *)&ip4->ip_dst;
 
-      dl->dl_flags   |= SCAMPER_DL_REC_FLAG_NET;
+      dl->dl_flags    = SCAMPER_DL_REC_FLAG_NET;
       dl->dl_net_type = SCAMPER_DL_REC_NET_TYPE_IP;
 
       pkt += iplen;
@@ -199,15 +212,19 @@ static int dl_parse_ip(scamper_dl_rec_t *dl, uint8_t *pktbuf, size_t pktlen)
       if((iplen = sizeof(struct ip6_hdr)) > len)
 	return 0;
 
+      memset(dl, 0, sizeof(scamper_dl_rec_t));
+
       dl->dl_af       = AF_INET6;
       dl->dl_ip_hl    = iplen;
       dl->dl_ip_flow  = ntohl(ip6->ip6_flow) & 0xfffff;
       dl->dl_ip_proto = ip6->ip6_nxt;
       dl->dl_ip_size  = ntohs(ip6->ip6_plen) + sizeof(struct ip6_hdr);
       dl->dl_ip_hlim  = ip6->ip6_hlim;
+      dl->dl_ip_tos   = (((pkt[0] & 0x0f) << 4) | (pkt[1] & 0xf0) >> 4);
       dl->dl_ip_src   = (uint8_t *)&ip6->ip6_src;
       dl->dl_ip_dst   = (uint8_t *)&ip6->ip6_dst;
-      dl->dl_flags   |= SCAMPER_DL_REC_FLAG_NET;
+
+      dl->dl_flags    = SCAMPER_DL_REC_FLAG_NET;
       dl->dl_net_type = SCAMPER_DL_REC_NET_TYPE_IP;
 
       pkt += iplen;
@@ -267,14 +284,16 @@ static int dl_parse_ip(scamper_dl_rec_t *dl, uint8_t *pktbuf, size_t pktlen)
    * a later fragment
    */
   if(dl->dl_ip_off != 0)
-    return 1;
+    {
+      dl->dl_net_raw = pktbuf;
+      dl->dl_net_rawlen = pktlen;
+      return 1;
+    }
 
   if(dl->dl_ip_proto == IPPROTO_UDP)
     {
-      if((int)sizeof(struct udphdr) > len)
-	{
-	  return 0;
-	}
+      if(sizeof(struct udphdr) > len)
+	return 0;
 
       udp = (struct udphdr *)pkt;
       dl->dl_udp_dport = ntohs(udp->uh_dport);
@@ -284,10 +303,8 @@ static int dl_parse_ip(scamper_dl_rec_t *dl, uint8_t *pktbuf, size_t pktlen)
     }
   else if(dl->dl_ip_proto == IPPROTO_TCP)
     {
-      if((int)sizeof(struct tcphdr) > len)
-	{
-	  return 0;
-	}
+      if(sizeof(struct tcphdr) > len)
+	return 0;
 
       tcp = (struct tcphdr *)pkt;
       dl->dl_tcp_dport  = ntohs(tcp->th_dport);
@@ -379,9 +396,7 @@ static int dl_parse_ip(scamper_dl_rec_t *dl, uint8_t *pktbuf, size_t pktlen)
     {
       /* the absolute minimum ICMP header size is 8 bytes */
       if(ICMP_MINLEN > len)
-	{
-	  return 0;
-	}
+	return 0;
 
       icmp4 = (struct icmp *)pkt;
       dl->dl_icmp_type = icmp4->icmp_type;
@@ -391,16 +406,12 @@ static int dl_parse_ip(scamper_dl_rec_t *dl, uint8_t *pktbuf, size_t pktlen)
 	{
 	case ICMP_UNREACH:
 	case ICMP_TIMXCEED:
-	  if(ICMP_MINLEN + (int)sizeof(struct ip) > len)
-	    {
-	      return 0;
-	    }
+	  if(ICMP_MINLEN + sizeof(struct ip) > len)
+	    return 0;
 
 	  if(dl->dl_icmp_type == ICMP_UNREACH &&
 	     dl->dl_icmp_code == ICMP_UNREACH_NEEDFRAG)
-	    {
-	      dl->dl_icmp_nhmtu = ntohs(icmp4->icmp_nextmtu);
-	    }
+	    dl->dl_icmp_nhmtu = ntohs(icmp4->icmp_nextmtu);
 
 	  ip4 = &icmp4->icmp_ip;
 
@@ -476,10 +487,8 @@ static int dl_parse_ip(scamper_dl_rec_t *dl, uint8_t *pktbuf, size_t pktlen)
   else if(dl->dl_ip_proto == IPPROTO_ICMPV6)
     {
       /* the absolute minimum ICMP header size is 8 bytes */
-      if((int)sizeof(struct icmp6_hdr) > len)
-	{
-	  return 0;
-	}
+      if(sizeof(struct icmp6_hdr) > len)
+	return 0;
 
       icmp6 = (struct icmp6_hdr *)pkt;
       dl->dl_icmp_type = icmp6->icmp6_type;
@@ -492,10 +501,8 @@ static int dl_parse_ip(scamper_dl_rec_t *dl, uint8_t *pktbuf, size_t pktlen)
 	case ICMP6_TIME_EXCEEDED:
 	case ICMP6_DST_UNREACH:
 	case ICMP6_PACKET_TOO_BIG:
-	  if((int)sizeof(struct ip6_hdr) + 8 > len)
-	    {
-	      return 0;
-	    }
+	  if(sizeof(struct ip6_hdr) + 8 > len)
+	    return 0;
 
 	  if(dl->dl_icmp_type == ICMP6_PACKET_TOO_BIG)
 	    {
@@ -507,14 +514,16 @@ static int dl_parse_ip(scamper_dl_rec_t *dl, uint8_t *pktbuf, size_t pktlen)
 	    }
 
 	  ip6 = (struct ip6_hdr *)pkt;
-	  pkt += sizeof(struct ip6_hdr);
 
 	  dl->dl_icmp_ip_proto = ip6->ip6_nxt;
 	  dl->dl_icmp_ip_size  = ntohs(ip6->ip6_plen) + sizeof(struct ip6_hdr);
 	  dl->dl_icmp_ip_hlim  = ip6->ip6_hlim;
 	  dl->dl_icmp_ip_flow  = ntohl(ip6->ip6_flow) & 0xfffff;
+	  dl->dl_icmp_ip_tos = ((pkt[0] & 0xf) << 4) | ((pkt[1] & 0xf0) >> 4);
 	  dl->dl_icmp_ip_src = (uint8_t *)&ip6->ip6_src;
 	  dl->dl_icmp_ip_dst = (uint8_t *)&ip6->ip6_dst;
+
+	  pkt += sizeof(struct ip6_hdr);
 
 	  if(dl->dl_icmp_ip_proto == IPPROTO_UDP)
 	    {
@@ -563,10 +572,55 @@ static int dl_parse_ip(scamper_dl_rec_t *dl, uint8_t *pktbuf, size_t pktlen)
       return 0;
     }
 
+  dl->dl_net_raw = pktbuf;
+  dl->dl_net_rawlen = pktlen;
   return 1;
 }
+#endif /* BUILDING_SCAMPER or TEST_DL_PARSE_IP */
 
-#ifndef TEST_DL_PARSE_IP
+/*
+ * dl_parse_arp
+ *
+ * pkt points to the beginning of an ARP payload.  given the length of the
+ * packet, parse the contents into a datalink record structure.
+ */
+#if defined(BUILDING_SCAMPER) || defined(TEST_DL_PARSE_ARP)
+#ifdef TEST_DL_PARSE_ARP
+int dl_parse_arp(scamper_dl_rec_t *dl, uint8_t *pkt, size_t len)
+#else
+static int dl_parse_arp(scamper_dl_rec_t *dl, uint8_t *pkt, size_t len)
+#endif
+{
+  size_t off;
+
+  /* need to at least have a header, and the bits after the arp header */
+  if(len <= 8 || (size_t)((pkt[4]*2) + (pkt[5]*2) + 8) > len)
+    return 0;
+
+  memset(dl, 0, sizeof(scamper_dl_rec_t));
+
+  dl->dl_arp_hrd = bytes_ntohs(pkt+0);
+  dl->dl_arp_pro = bytes_ntohs(pkt+2);
+  dl->dl_arp_hln = pkt[4];
+  dl->dl_arp_pln = pkt[5];
+  dl->dl_arp_op  = bytes_ntohs(pkt+6);
+
+  off = 8;
+  dl->dl_arp_sha = pkt+off; off += dl->dl_arp_hln;
+  dl->dl_arp_spa = pkt+off; off += dl->dl_arp_pln;
+  dl->dl_arp_tha = pkt+off; off += dl->dl_arp_hln;
+  dl->dl_arp_tpa = pkt+off;
+
+  /* completed record is an arp frame */
+  dl->dl_net_type = SCAMPER_DL_REC_NET_TYPE_ARP;
+
+  dl->dl_net_raw    = pkt;
+  dl->dl_net_rawlen = len;
+  return 1;
+}
+#endif /* BUILDING_SCAMPER or TEST_DL_PARSE_ARP */
+
+#ifdef BUILDING_SCAMPER
 
 /*
  * dlt_raw_cb
@@ -578,16 +632,7 @@ static int dl_parse_ip(scamper_dl_rec_t *dl, uint8_t *pktbuf, size_t pktlen)
  */
 static int dlt_raw_cb(scamper_dl_rec_t *dl, uint8_t *pkt, size_t len)
 {
-  int ret;
-
-  if((ret = dl_parse_ip(dl, pkt, len)) != 0)
-    {
-      dl->dl_type = SCAMPER_DL_TYPE_RAW;
-      dl->dl_net_raw = pkt;
-      dl->dl_net_rawlen = len;
-    }
-
-  return ret;
+  return dl_parse_ip(dl, pkt, len);
 }
 
 /*
@@ -601,26 +646,14 @@ static int dlt_raw_cb(scamper_dl_rec_t *dl, uint8_t *pkt, size_t len)
 static int dlt_null_cb(scamper_dl_rec_t *dl, uint8_t *pkt, size_t len)
 {
   uint32_t pf;
-  int ret;
 
   /* ensure the packet holds at least 4 bytes for the psuedo header */
   if(len <= 4)
-    {
-      return 0;
-    }
+    return 0;
 
   memcpy(&pf, pkt, 4);
   if(pf == PF_INET || pf == PF_INET6)
-    {
-      if((ret = dl_parse_ip(dl, pkt+4, len-4)) != 0)
-	{
-	  dl->dl_type = SCAMPER_DL_TYPE_NULL;
-	  dl->dl_net_raw = pkt+4;
-	  dl->dl_net_rawlen = len-4;
-	}
-
-      return ret;
-    }
+    return dl_parse_ip(dl, pkt+4, len-4);
 
   return 0;
 }
@@ -640,7 +673,6 @@ static int dlt_null_cb(scamper_dl_rec_t *dl, uint8_t *pkt, size_t len)
 static int dlt_en10mb_cb(scamper_dl_rec_t *dl, uint8_t *pkt, size_t len)
 {
   uint16_t u16;
-  size_t off, s;
 
   /* ensure the packet holds at least the length of the ethernet header */
   if(len <= 14)
@@ -648,45 +680,11 @@ static int dlt_en10mb_cb(scamper_dl_rec_t *dl, uint8_t *pkt, size_t len)
 
   u16 = bytes_ntohs(pkt+12);
   if(u16 == ETHERTYPE_IP || u16 == ETHERTYPE_IPV6)
-    {
-      if(dl_parse_ip(dl, pkt+14, len-14) == 0)
-	return 0;
-    }
+    return dl_parse_ip(dl, pkt+14, len-14);
   else if(u16 == ETHERTYPE_ARP)
-    {
-      /* need to at least have a header */
-      if(14 + 8 >= len)
-	return 0;
+    return dl_parse_arp(dl, pkt+14, len-14);
 
-      off = 14;
-      dl->dl_arp_hrd = bytes_ntohs(pkt+off); off += 2;
-      dl->dl_arp_pro = bytes_ntohs(pkt+off); off += 2;
-      dl->dl_arp_hln = pkt[off++];
-      dl->dl_arp_pln = pkt[off++];
-      dl->dl_arp_op  = bytes_ntohs(pkt+off); off += 2;
-
-      /* make sure all the bits are found after the arp header */
-      s = (dl->dl_arp_hln*2) + (dl->dl_arp_pln*2) + 14 + 8;
-      if(s > len)
-	return 0;
-
-      dl->dl_arp_sha = pkt+off; off += dl->dl_arp_hln;
-      dl->dl_arp_spa = pkt+off; off += dl->dl_arp_pln;
-      dl->dl_arp_tha = pkt+off; off += dl->dl_arp_hln;
-      dl->dl_arp_tpa = pkt+off;
-
-      /* completed record is an arp frame */
-      dl->dl_net_type = SCAMPER_DL_REC_NET_TYPE_ARP;
-    }
-  else return 0;
-
-  dl->dl_type       = SCAMPER_DL_TYPE_ETHERNET;
-  dl->dl_lladdr_dst = pkt;
-  dl->dl_lladdr_src = pkt+6;
-  dl->dl_net_raw    = pkt+14;
-  dl->dl_net_rawlen = len-14;
-
-  return 1;
+  return 0;
 }
 
 /*
@@ -699,36 +697,22 @@ static int dlt_en10mb_cb(scamper_dl_rec_t *dl, uint8_t *pkt, size_t len)
 #ifdef HAVE_FIREWIRE
 static int dlt_firewire_cb(scamper_dl_rec_t *dl, uint8_t *pkt, size_t len)
 {
-  int ret;
   uint16_t type;
 
   /* ensure the packet holds at least the length of the firewire header */
   if(len <= 18)
-    {
-      return 0;
-    }
+    return 0;
 
   memcpy(&type, pkt+16, 2); type = ntohs(type);
   if(type == ETHERTYPE_IP || type == ETHERTYPE_IPV6)
-    {
-      if((ret = dl_parse_ip(dl, pkt+18, len-18)) != 0)
-	{
-	  dl->dl_type = SCAMPER_DL_TYPE_FIREWIRE;
-	  dl->dl_lladdr_dst = pkt;
-	  dl->dl_lladdr_src = pkt + 8;
-	  dl->dl_net_raw    = pkt + 18;
-	  dl->dl_net_rawlen = len - 18;
-	}
-
-      return ret;
-    }
+    return dl_parse_ip(dl, pkt+18, len-18);
 
   return 0;
 }
 #endif
 
 #if defined(HAVE_BPF)
-static int dl_bpf_open_dev(char *dev, const size_t len)
+static int dl_bpf_open_dev(char *dev, size_t len)
 {
   int i=0, fd;
 
@@ -738,14 +722,9 @@ static int dl_bpf_open_dev(char *dev, const size_t len)
       if((fd = open(dev, O_RDWR)) == -1)
 	{
 	  if(errno == EBUSY)
-	    {
-	      continue;
-	    }
-	  else
-	    {
-	      printerror(__func__, "could not open %s", dev);
-	      return -1;
-	    }
+	    continue;
+	  printerror(__func__, "could not open %s", dev);
+	  return -1;
 	}
       else break;
     }
@@ -754,7 +733,7 @@ static int dl_bpf_open_dev(char *dev, const size_t len)
   return fd;
 }
 
-static int dl_bpf_open(const int ifindex)
+static int dl_bpf_open(int ifindex)
 {
   struct ifreq ifreq;
   char dev[16];
@@ -813,7 +792,7 @@ static int dl_bpf_node_init(const scamper_fd_t *fdn, scamper_dl_t *node)
 {
   char ifname[IFNAMSIZ];
   u_int tmp;
-  int ifindex, fd;
+  int fd;
   uint8_t *buf;
 
   /* get the file descriptor associated with the fd node */
@@ -822,16 +801,10 @@ static int dl_bpf_node_init(const scamper_fd_t *fdn, scamper_dl_t *node)
       goto err;
     }
 
-  /* get the interface index */
-  if(scamper_fd_ifindex(fdn, &ifindex) != 0)
-    {
-      goto err;
-    }
-
   /* convert the interface index to a name */
-  if(if_indextoname((unsigned int)ifindex, ifname) == NULL)
+  if(if_indextoname((unsigned int)node->ifindex, ifname) == NULL)
     {
-      printerror(__func__,"if_indextoname %d failed", ifindex);
+      printerror(__func__,"if_indextoname %d failed", node->ifindex);
       goto err;
     }
 
@@ -888,7 +861,7 @@ static int dl_bpf_node_init(const scamper_fd_t *fdn, scamper_dl_t *node)
     }
 
   scamper_debug(__func__, "bpf if %s index %d buflen %d datalink %d",
-		ifname, ifindex, node->readbuf_len, node->type);
+		ifname, node->ifindex, node->readbuf_len, node->type);
 
   tmp = 1;
   if(ioctl(fd, BIOCIMMEDIATE, &tmp) == -1)
@@ -920,14 +893,19 @@ static int dl_bpf_init(void)
   int  fd;
   char buf[16];
   int  err;
+  int  rc = -1;
+
+#ifdef HAVE_SETEUID
+  uid_t uid, euid;
+  if(scamper_seteuid_raise(&uid, &euid) != 0)
+    return -1;
+#endif
 
   if((fd = dl_bpf_open_dev(buf, sizeof(buf))) == -1)
     {
       if(errno == ENXIO)
-	{
-	  return 0;
-	}
-      return -1;
+	rc = 0;
+      goto done;
     }
 
   err = ioctl(fd, BIOCVERSION, &bv);
@@ -935,8 +913,12 @@ static int dl_bpf_init(void)
   if(err == -1)
     {
       printerror(__func__, "BIOCVERSION failed");
-      return -1;
+      goto done;
     }
+
+#ifdef HAVE_SETEUID
+  scamper_seteuid_lower(&uid, &euid);
+#endif
 
   scamper_debug(__func__, "bpf version %d.%d", bv.bv_major, bv.bv_minor);
   if(bv.bv_major != BPF_MAJOR_VERSION || bv.bv_minor < BPF_MINOR_VERSION)
@@ -944,7 +926,7 @@ static int dl_bpf_init(void)
       printerror_msg(__func__, "bpf ver %d.%d is incompatible with %d.%d",
 		     bv.bv_major, bv.bv_minor,
 		     BPF_MAJOR_VERSION, BPF_MINOR_VERSION);
-      return -1;
+      goto done;
     }
 
   osinfo = scamper_osinfo_get();
@@ -955,19 +937,24 @@ static int dl_bpf_init(void)
       printerror_msg(__func__,
 		     "BPF file descriptors do not work with "
 		     "select in FreeBSD 4.3 or 4.4");
-      return -1;
+      goto done;
     }
 
-  return 0;
+  rc = 0;
+
+ done:
+#ifdef HAVE_SETEUID
+  scamper_seteuid_lower(&uid, &euid);
+#endif
+  return rc;
 }
 
-static int dl_bpf_read(const int fd, scamper_dl_t *node)
+static int dl_bpf_read(int fd, scamper_dl_t *node)
 {
   struct bpf_hdr    *bpf_hdr;
   scamper_dl_rec_t   dl;
   ssize_t            len;
   uint8_t           *buf = readbuf;
-  int                ifindex;
 
   while((len = read(fd, buf, node->readbuf_len)) == -1)
     {
@@ -978,27 +965,17 @@ static int dl_bpf_read(const int fd, scamper_dl_t *node)
       return -1;
     }
 
-  /* record the ifindex now, as the cb may need it */
-  if(scamper_fd_ifindex(node->fdn, &ifindex) != 0)
-    {
-      return -1;
-    }
-
   while(buf < readbuf + len)
     {
       bpf_hdr = (struct bpf_hdr *)buf;
-
-      /* reset the datalink record */
-      memset(&dl, 0, sizeof(dl));
-      dl.dl_ifindex = ifindex;
 
       if(node->dlt_cb(&dl, buf + bpf_hdr->bh_hdrlen, bpf_hdr->bh_caplen))
 	{
 	  /* bpf always supplies a timestamp */
 	  dl.dl_flags |= SCAMPER_DL_REC_FLAG_TIMESTAMP;
-
 	  dl.dl_tv.tv_sec  = bpf_hdr->bh_tstamp.tv_sec;
 	  dl.dl_tv.tv_usec = bpf_hdr->bh_tstamp.tv_usec;
+	  dl.dl_ifindex = node->ifindex;
 
 	  scamper_task_handledl(&dl);
 	}
@@ -1009,8 +986,7 @@ static int dl_bpf_read(const int fd, scamper_dl_t *node)
   return 0;
 }
 
-static int dl_bpf_tx(const scamper_dl_t *node,
-		     const uint8_t *pkt, const size_t len)
+static int dl_bpf_tx(const scamper_dl_t *node, const uint8_t *pkt, size_t len)
 {
   ssize_t wb;
 
@@ -1026,23 +1002,52 @@ static int dl_bpf_tx(const scamper_dl_t *node,
   return 0;
 }
 
-static int dl_bpf_filter(scamper_dl_t *node, struct bpf_insn *insns, int len)
+#elif defined(__linux__)
+
+static int linux_read_sll(scamper_dl_rec_t *dl, struct sockaddr_ll *sll,
+			  uint8_t *buf, size_t len)
 {
-  struct bpf_program prog;
+  uint16_t proto;
+  int rc = 0;
 
-  prog.bf_len   = len;
-  prog.bf_insns = insns;
+  /* don't see loopback packets twice */
+  if(sll->sll_pkttype == PACKET_OUTGOING && sll->sll_ifindex == lo_ifindex)
+    return 0;
 
-  if(ioctl(scamper_fd_fd_get(node->fdn), BIOCSETF, (caddr_t)&prog) == -1)
+  switch(sll->sll_hatype)
     {
-      printerror(__func__, "BIOCSETF failed");
-      return -1;
+    case ARPHRD_ETHER:
+    case ARPHRD_LOOPBACK:
+      proto = ntohs(sll->sll_protocol);
+      if(proto == ETHERTYPE_IP || proto == ETHERTYPE_IPV6)
+	rc = dl_parse_ip(dl, buf, len);
+      else if(proto == ETHERTYPE_ARP)
+	rc = dl_parse_arp(dl, buf, len);
+      break;
+
+#if defined(ARPHRD_SIT)
+    case ARPHRD_SIT:
+#endif
+#if defined(ARPHRD_VOID)
+    case ARPHRD_VOID:
+#endif
+    case ARPHRD_PPP:
+      rc = dl_parse_ip(dl, buf, len);
+      break;
+
+#if defined(ARPHRD_IEEE1394)
+    case ARPHRD_IEEE1394:
+      proto = ntohs(sll->sll_protocol);
+      if(proto == ETHERTYPE_IP || proto == ETHERTYPE_IPV6)
+	rc = dl_parse_ip(dl, buf, len);
+      break;
+#endif
     }
 
-  return 0;
+  if(rc != 0)
+    dl->dl_ifindex = sll->sll_ifindex;
+  return rc;
 }
-
-#elif defined(__linux__)
 
 #ifdef HAVE_STRUCT_TPACKET_REQ3
 /*
@@ -1087,6 +1092,7 @@ static void ring_stats(scamper_dl_t *node)
 static int ring_handle_frame(scamper_dl_t *node, struct tpacket3_hdr *frame)
 {
   scamper_dl_rec_t dl;
+  struct sockaddr_ll *sll;
   uint8_t *buf;
   ssize_t len;
 
@@ -1102,21 +1108,29 @@ static int ring_handle_frame(scamper_dl_t *node, struct tpacket3_hdr *frame)
   if((frame->tp_status & TP_STATUS_LOSING) == TP_STATUS_LOSING)
     ring_stats(node);
 
-  /* reset the datalink record */
-  memset(&dl, 0, sizeof(dl));
+  sll = (struct sockaddr_ll *)((uint8_t *)frame +
+			       TPACKET_ALIGN(sizeof(struct tpacket3_hdr)));
+
+  /* check if we want this packet, and populate the dl record */
+  if(node->ifindex != 0)
+    {
+      if(sll->sll_pkttype == PACKET_OUTGOING && node->ifindex == lo_ifindex)
+	return 0;
+      if(node->dlt_cb(&dl, buf, len) == 0)
+	return 0;
+      dl.dl_ifindex = node->ifindex;
+    }
+  else
+    {
+      if(linux_read_sll(&dl, sll, buf, len) == 0)
+	return 0;
+    }
 
   /* populate dl timestamp info from the frame header */
   dl.dl_flags |= SCAMPER_DL_REC_FLAG_TIMESTAMP;
   dl.dl_tv.tv_sec = frame->tp_sec;
   dl.dl_tv.tv_usec = frame->tp_nsec / 1000;
-
-  /* record the ifindex now, as the cb routine may need it */
-  if(scamper_fd_ifindex(node->fdn, &dl.dl_ifindex) != 0)
-    return -1;
-
-  /* check if we want this packet, and populate the dl record */
-  if(node->dlt_cb(&dl, buf, len))
-    scamper_task_handledl(&dl);
+  scamper_task_handledl(&dl);
 
   return 0;
 }
@@ -1188,10 +1202,8 @@ static int ring_init(scamper_dl_t *dl)
   unsigned int block_cnt = scamper_option_ring_blocks();
   unsigned int frame_cnt = (block_size / frame_size) * block_cnt;
   unsigned int i;
-  int pkt_version = TPACKET_V3;
   int fd = scamper_fd_fd_get(dl->fdn);
   int flags;
-  size_t len;
 
   if((ring = malloc_zero(sizeof(struct ring))) == NULL)
     {
@@ -1219,15 +1231,13 @@ static int ring_init(scamper_dl_t *dl)
                 ring->req.tp_block_size, ring->req.tp_block_nr,
                 ring->req.tp_frame_size, ring->req.tp_frame_nr);
 
-  len = sizeof(pkt_version);
-  if(setsockopt(fd, SOL_PACKET, PACKET_VERSION, &pkt_version, len) != 0)
+  if(setsockopt_int(fd, SOL_PACKET, PACKET_VERSION, TPACKET_V3) != 0)
     {
       printerror(__func__, "PACKET_VERSION failed");
       goto err;
     }
 
-  len = sizeof(ring->req);
-  if(setsockopt(fd, SOL_PACKET, PACKET_RX_RING, &ring->req, len) != 0)
+  if(setsockopt(fd, SOL_PACKET, PACKET_RX_RING, &ring->req, sizeof(ring->req)) != 0)
     {
       printerror(__func__, "PACKET_RX_RING failed");
       goto err;
@@ -1276,13 +1286,15 @@ static int ring_init(scamper_dl_t *dl)
 }
 #endif /* HAVE_STRUCT_TPACKET_REQ3 */
 
-static int dl_linux_open(const int ifindex)
+static int dl_linux_open(int ifindex)
 {
   struct sockaddr_ll sll;
   int fd;
 
-  /* open the socket in non cooked mode for now */
-  if((fd = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ALL))) == -1)
+  /* open the socket in non cooked mode if not the "any" interface */
+  if((fd = socket(PF_PACKET,
+		  ifindex != 0 ? SOCK_RAW : SOCK_DGRAM,
+		  htons(ETH_P_ALL))) == -1)
     {
       printerror(__func__, "could not open PF_PACKET");
       return -1;
@@ -1307,21 +1319,24 @@ static int dl_linux_node_init(const scamper_fd_t *fdn, scamper_dl_t *node)
 {
   struct ifreq ifreq;
   char ifname[IFNAMSIZ];
-  int fd, ifindex;
-
-  if(scamper_fd_ifindex(fdn, &ifindex) != 0)
-    {
-      goto err;
-    }
+  int fd;
 
   if((fd = scamper_fd_fd_get(fdn)) < 0)
     {
       goto err;
     }
 
-  if(if_indextoname(ifindex, ifname) == NULL)
+  if(node->ifindex == 0)
     {
-      printerror(__func__, "if_indextoname %d failed", ifindex);
+      node->tx_type = SCAMPER_DL_TX_UNSUPPORTED;
+      node->type = -1;
+      node->dlt_cb = NULL;
+      goto finish;
+    }
+
+  if(if_indextoname(node->ifindex, ifname) == NULL)
+    {
+      printerror(__func__, "if_indextoname %d failed", node->ifindex);
       goto err;
     }
 
@@ -1375,6 +1390,8 @@ static int dl_linux_node_init(const scamper_fd_t *fdn, scamper_dl_t *node)
       goto err;
     }
 
+ finish:
+
 #ifdef HAVE_STRUCT_TPACKET_REQ3
   if(scamper_option_ring() && ring_init(node) != 0)
     {
@@ -1389,21 +1406,21 @@ static int dl_linux_node_init(const scamper_fd_t *fdn, scamper_dl_t *node)
   return -1;
 }
 
-static int linux_read(const int fd, scamper_dl_t *node)
+static int linux_read(int fd, scamper_dl_t *node)
 {
   scamper_dl_rec_t   dl;
   ssize_t            len;
-  struct sockaddr_ll from;
+  struct sockaddr_ll sll;
   socklen_t          fromlen;
   size_t             s;
 
-  fromlen = sizeof(from);
+  fromlen = sizeof(sll);
   while((len = recvfrom(fd, readbuf, readbuf_len, MSG_TRUNC,
-			(struct sockaddr *)&from, &fromlen)) == -1)
+			(struct sockaddr *)&sll, &fromlen)) == -1)
     {
       if(errno == EINTR)
 	{
-	  fromlen = sizeof(from);
+	  fromlen = sizeof(sll);
 	  continue;
 	}
       if(errno == EAGAIN)
@@ -1422,35 +1439,32 @@ static int linux_read(const int fd, scamper_dl_t *node)
   else
     s = (size_t)len;
 
-  /* reset the datalink record */
-  memset(&dl, 0, sizeof(dl));
-
-  /* record the ifindex now, as the cb routine may need it */
-  if(scamper_fd_ifindex(node->fdn, &dl.dl_ifindex) != 0)
+  if(node->ifindex != 0)
     {
-      return -1;
+      if(sll.sll_pkttype == PACKET_OUTGOING && node->ifindex == lo_ifindex)
+	return 0;
+      if(node->dlt_cb(&dl, readbuf, s) == 0)
+	return 0;
+      dl.dl_ifindex = node->ifindex;      
+    }
+  else
+    {
+      if(linux_read_sll(&dl, &sll, readbuf, s) == 0)
+	return 0;
     }
 
-  /* if the packet passes the filter, we need to get the time it was rx'd */
-  if(node->dlt_cb(&dl, readbuf, s))
-    {
-      /* scamper treats the failure of this ioctl as non-fatal */
-      if(ioctl(fd, SIOCGSTAMP, &dl.dl_tv) == 0)
-	{
-	  dl.dl_flags |= SCAMPER_DL_REC_FLAG_TIMESTAMP;
-	}
-      else
-	{
-	  printerror(__func__, "could not SIOCGSTAMP on fd %d", fd);
-	}
-
-      scamper_task_handledl(&dl);
-    }
+  /*
+   * if the packet passes the filter, we need to get the time it was rx'd.
+   * scamper treats the failure of this ioctl as non-fatal
+   */
+  if(ioctl(fd, SIOCGSTAMP, &dl.dl_tv) == 0)
+    dl.dl_flags |= SCAMPER_DL_REC_FLAG_TIMESTAMP;
+  scamper_task_handledl(&dl);
 
   return 0;
 }
 
-static int dl_linux_read(const int fd, scamper_dl_t *node)
+static int dl_linux_read(int fd, scamper_dl_t *node)
 {
 #ifdef HAVE_STRUCT_TPACKET_REQ3
   if(scamper_option_ring())
@@ -1459,23 +1473,17 @@ static int dl_linux_read(const int fd, scamper_dl_t *node)
   return linux_read(fd, node);
 }
 
-static int dl_linux_tx(const scamper_dl_t *node,
-		       const uint8_t *pkt, const size_t len)
+static int dl_linux_tx(const scamper_dl_t *node,const uint8_t *pkt,size_t len)
 {
   struct sockaddr_ll sll;
   struct sockaddr *sa = (struct sockaddr *)&sll;
   ssize_t wb;
-  int fd, ifindex;
+  int fd;
   uint8_t ipv;
-
-  if(scamper_fd_ifindex(node->fdn, &ifindex) != 0)
-    {
-      return -1;
-    }
 
   memset(&sll, 0, sizeof(sll));
   sll.sll_family = AF_PACKET;
-  sll.sll_ifindex = ifindex;
+  sll.sll_ifindex = node->ifindex;
 
   switch(node->tx_type)
     {
@@ -1512,28 +1520,40 @@ static int dl_linux_tx(const scamper_dl_t *node,
   return 0;
 }
 
-static int dl_linux_filter(scamper_dl_t *node,
-			   struct sock_filter *insns, int len)
+static int dl_linux_init(void)
 {
-  struct sock_fprog prog;
-  int i;
+  struct ifreq ifr;
+  int fd;
 
-  for(i=0; i<len; i++)
+#ifdef HAVE_SETEUID
+  uid_t uid, euid;
+#endif
+
+  readbuf_len = 128;
+  if((readbuf = malloc_zero(readbuf_len)) == NULL)
     {
-      if(insns[i].code == (BPF_RET+BPF_K) && insns[i].k > 0)
-	{
-	  insns[i].k = 65535;
-	}
+      printerror(__func__, "could not malloc readbuf");
+      readbuf_len = 0;
+      return -1;
     }
 
-  prog.len    = len;
-  prog.filter = insns;
+#ifdef HAVE_SETEUID
+  if(scamper_seteuid_raise(&uid, &euid) != 0)
+    return -1;
+#endif
+  fd = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
+#ifdef HAVE_SETEUID
+  scamper_seteuid_lower(&uid, &euid);
+#endif
 
-  if(setsockopt(scamper_fd_fd_get(node->fdn), SOL_SOCKET, SO_ATTACH_FILTER,
-		(caddr_t)&prog, sizeof(prog)) == -1)
+  /* get the loopback ifindex so we can filter duplicate replies */
+  if(fd != -1)
     {
-      printerror(__func__, "SO_ATTACH_FILTER failed");
-      return -1;
+      memset(&ifr, 0, sizeof(ifr));
+      ifr.ifr_name[0] = 'l'; ifr.ifr_name[1] = 'o'; /* lo */
+      if(ioctl(fd, SIOCGIFINDEX, &ifr) != -1)
+	lo_ifindex = ifr.ifr_ifindex;
+      close(fd);
     }
 
   return 0;
@@ -1541,7 +1561,7 @@ static int dl_linux_filter(scamper_dl_t *node,
 
 #elif defined(HAVE_DLPI)
 
-static int dl_dlpi_open(const int ifindex)
+static int dl_dlpi_open(int ifindex)
 {
   char ifname[5+IFNAMSIZ];
   int fd;
@@ -1562,7 +1582,7 @@ static int dl_dlpi_open(const int ifindex)
   return fd;
 }
 
-static int dl_dlpi_req(const int fd, void *req, size_t len)
+static int dl_dlpi_req(int fd, void *req, size_t len)
 {
   union	DL_primitives *dlp;
   struct strbuf ctl;
@@ -1581,7 +1601,7 @@ static int dl_dlpi_req(const int fd, void *req, size_t len)
   return 0;
 }
 
-static int dl_dlpi_ack(const int fd, void *ack, int primitive)
+static int dl_dlpi_ack(int fd, void *ack, int primitive)
 {
   union	DL_primitives *dlp;
   struct strbuf ctl;
@@ -1608,7 +1628,7 @@ static int dl_dlpi_ack(const int fd, void *ack, int primitive)
   return 0;
 }
 
-static int dl_dlpi_promisc(const int fd, const int level)
+static int dl_dlpi_promisc(int fd, int level)
 {
   dl_promiscon_req_t promiscon_req;
   uint32_t buf[MAXDLBUF];
@@ -1657,7 +1677,6 @@ static int dl_dlpi_node_init(const scamper_fd_t *fdn, scamper_dl_t *node)
 
 #ifndef NDEBUG
   char             ifname[IFNAMSIZ];
-  int              ifindex;
 #endif
 
   if((fd = scamper_fd_fd_get(fdn)) < 0)
@@ -1792,20 +1811,19 @@ static int dl_dlpi_node_init(const scamper_fd_t *fdn, scamper_dl_t *node)
     }
 
 #ifndef NDEBUG
-  if(scamper_fd_ifindex(fdn, &ifindex) != 0 ||
-     if_indextoname(ifindex, ifname) == NULL)
+  if(if_indextoname(node->ifindex, ifname) == NULL)
     {
       strncpy(ifname, "<null>", sizeof(ifname)-1);
       ifname[sizeof(ifname)-1] = '\0';
     }
   scamper_debug(__func__, "dlpi if %s index %d datalink %d",
-		ifname, ifindex, node->type);
+		ifname, node->ifindex, node->type);
 #endif
 
   return 0;
 }
 
-static int dl_dlpi_read(const int fd, scamper_dl_t *node)
+static int dl_dlpi_read(int fd, scamper_dl_t *node)
 {
   scamper_dl_rec_t  dl;
   struct strbuf     data;
@@ -1827,25 +1845,21 @@ static int dl_dlpi_read(const int fd, scamper_dl_t *node)
   while(buf < readbuf + data.len)
     {
       sbh = (struct sb_hdr *)buf;
-
-      memset(&dl, 0, sizeof(dl));
-      dl.dl_flags = SCAMPER_DL_REC_FLAG_TIMESTAMP;
-
       if(node->dlt_cb(&dl, buf + sizeof(struct sb_hdr), sbh->sbh_msglen))
 	{
+	  dl.dl_flags = SCAMPER_DL_REC_FLAG_TIMESTAMP;
 	  dl.dl_tv.tv_sec  = sbh->sbh_timestamp.tv_sec;
 	  dl.dl_tv.tv_usec = sbh->sbh_timestamp.tv_usec;
+	  dl.dl_ifindex    = node->ifindex;
 	  scamper_task_handledl(&dl);
 	}
-
       buf += sbh->sbh_totlen;
     }
 
   return -1;
 }
 
-static int dl_dlpi_tx(const scamper_dl_t *node,
-		      const uint8_t *pkt, const size_t len)
+static int dl_dlpi_tx(const scamper_dl_t *node, const uint8_t *pkt, size_t len)
 {
   struct strbuf data;
   int fd;
@@ -1866,45 +1880,456 @@ static int dl_dlpi_tx(const scamper_dl_t *node,
   return 0;
 }
 
+static int dl_dlpi_init(void)
+{
+  readbuf_len = 65536; /* magic obtained from pcap-dlpi.c */
+  if((readbuf = malloc_zero(readbuf_len)) == NULL)
+    {
+      printerror(__func__, "could not malloc readbuf");
+      readbuf_len = 0;
+      return -1;
+    }
+  return 0;
+}
+
 #endif
 
 #if defined(HAVE_BPF_FILTER)
 
 #if defined(HAVE_BPF)
-static void bpf_stmt(struct bpf_insn *insn, uint16_t code, uint32_t k)
+static void bpf_stmt(struct bpf_insn *insns, size_t len, size_t *off,
+		     uint16_t code, uint32_t k)
 #else
-static void bpf_stmt(struct sock_filter *insn, uint16_t code, uint32_t k)
+static void bpf_stmt(struct sock_filter *insns, size_t len, size_t *off,
+		     uint16_t code, uint32_t k)
 #endif
 {
-  insn->code = code;
-  insn->jt   = 0;
-  insn->jf   = 0;
-  insn->k    = k;
+  if(*off >= len)
+    return;
+  insns[*off].code = code;
+  insns[*off].jt   = 0;
+  insns[*off].jf   = 0;
+  insns[*off].k    = k;
+  (*off)++;
   return;
 }
 
-static int dl_filter(scamper_dl_t *node)
+#if defined(__linux__) || defined(BIOCSETFNR)
+#if defined(HAVE_BPF)
+static void bpf_jump(struct bpf_insn *insns, size_t len, size_t *off,
+		     uint16_t code, uint32_t k, uint8_t jt, uint8_t jf)
+#else
+static void bpf_jump(struct sock_filter *insns, size_t len, size_t *off,
+		     uint16_t code, uint32_t k, uint8_t jt, uint8_t jf)
+#endif
+{
+  if(*off >= len)
+    return;
+  insns[*off].code = code;
+  insns[*off].jt   = jt;
+  insns[*off].jf   = jf;
+  insns[*off].k    = k;
+  (*off)++;
+  return;
+}
+#endif /* __linux__ or BIOCSETFNR */
+
+#if defined(__linux__) || defined(BIOCSETFNR)
+#if defined(HAVE_BPF)
+static int dl_filter_compile(const scamper_dl_t *node,
+			     struct bpf_program *prog,
+			     const uint16_t *ports, size_t portc)
+#else
+static int dl_filter_compile(const scamper_dl_t *node,
+			     struct sock_fprog *prog,
+			     const uint16_t *ports, size_t portc)
+#endif
 {
 #if defined(HAVE_BPF)
-  struct bpf_insn insns[1];
+  struct bpf_insn *insns = NULL;
 #else
-  struct sock_filter insns[1];
+  struct sock_filter *insns = NULL;
 #endif
 
-  bpf_stmt(&insns[0], BPF_RET+BPF_K, 65535);
+  uint32_t ipv4_c, ipv6_c, udp4_c, udp6_c, tcp4_c, tcp6_c, ip_off, k_dlt;
+  const uint16_t *udp4_ports; uint16_t udp4_portc;
+  const uint16_t *tcp4_ports; uint16_t tcp4_portc;
+  const uint16_t *udp6_ports; uint16_t udp6_portc;
+  const uint16_t *tcp6_ports; uint16_t tcp6_portc;
+  uint16_t i;
+  size_t len, off = 0;
 
-#if defined(HAVE_BPF)
-  if(dl_bpf_filter(node, insns, 1) == -1)
-#elif defined(__linux__)
-  if(dl_linux_filter(node, insns, 1) == -1)
-#endif
+  udp4_portc = ports[0]; udp4_ports = ports + 4;
+  tcp4_portc = ports[1]; tcp4_ports = udp4_ports + udp4_portc;
+  udp6_portc = ports[2]; udp6_ports = tcp4_ports + tcp4_portc;
+  tcp6_portc = ports[3]; tcp6_ports = udp6_ports + udp6_portc;
+
+  ipv4_c = 4;
+  if(udp4_portc > 0 || tcp4_portc > 0)
     {
+      ipv4_c += 1;
+      if(udp4_portc > 0)
+	{
+	  udp4_c = (udp4_portc * 2) + 2;
+	  ipv4_c += (1 + udp4_c);
+	}
+      if(tcp4_portc > 0)
+	{
+	  tcp4_c = (tcp4_portc * 2) + 2;
+	  ipv4_c += (1 + tcp4_c);
+	}
+    }
+
+  ipv6_c = 2 + 4;
+  if(udp6_portc > 0 || tcp6_portc > 0)
+    {
+      if(udp6_portc > 0)
+	{
+	  udp6_c = (udp6_portc * 2) + 2;
+	  ipv6_c += (1 + udp6_c);
+	}
+      if(tcp6_portc > 0)
+	{
+	  tcp6_c = (tcp6_portc * 2) + 2;
+	  ipv6_c += (1 + tcp6_c);
+	}
+    }
+
+  if(node->dlt_cb == dlt_en10mb_cb)
+    len = 4;
+#ifdef HAVE_BPF
+  else if(node->dlt_cb == dlt_null_cb)
+    len = 3;
+#endif
+  else if(node->dlt_cb == dlt_raw_cb)
+    len = 4;
+  else
+    return -1;
+
+  len += 2 + ipv4_c + ipv6_c;
+
+#ifdef __linux__
+  /* prog.len is an unsigned short on linux */
+  if(len > UINT16_MAX)
+    return -1;
+#endif
+
+#ifdef HAVE_BPF
+  if((insns = malloc(sizeof(struct bpf_insn) * len)) == NULL)
+    return -1;
+#else
+  if((insns = malloc(sizeof(struct sock_filter) * len)) == NULL)
+    return -1;
+#endif
+
+  if(node->dlt_cb == dlt_en10mb_cb)
+    {
+      ip_off = 14;
+      k_dlt = ETHERTYPE_IP;
+      bpf_stmt(insns, len, &off, BPF_LD+BPF_ABS+BPF_H, 12);
+      bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, k_dlt,
+	       2,
+	       0);
+      k_dlt = ETHERTYPE_IPV6;
+      bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, k_dlt,
+	       ipv4_c + 1,
+	       0);
+      k_dlt = ETHERTYPE_ARP;
+      bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, k_dlt,
+	       len - off - 2,
+	       len - off - 3);
+    }
+#ifdef HAVE_BPF
+  else if(node->dlt_cb == dlt_null_cb)
+    {
+      ip_off = 4;
+      k_dlt = htonl(PF_INET);
+      bpf_stmt(insns, len, &off, BPF_LD+BPF_ABS+BPF_W, 0);
+      bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, k_dlt, 1, 0);
+      k_dlt = htonl(PF_INET6);
+      bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, k_dlt, ipv4_c,
+	       len - off - 3);
+    }
+#endif
+  else if(node->dlt_cb == dlt_raw_cb)
+    {
+      ip_off = 0;
+      bpf_stmt(insns, len, &off, BPF_LD+BPF_ABS+BPF_B, 0);
+      bpf_stmt(insns, len, &off, BPF_ALU+BPF_RSH+BPF_K, 4);
+      bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, 4, 1, 0);
+      bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, 6, ipv4_c,
+	       len - off - 3);
+    }
+  else
+    {
+      free(insns);
       return -1;
     }
 
-   return 0;
-}
+  /* we know the packet is IPv4.  if fragment offset is > 0, pass it */
+  bpf_stmt(insns, len, &off, BPF_LD+BPF_ABS+BPF_H, ip_off+6);
+  bpf_jump(insns, len, &off, BPF_JMP+BPF_JSET+BPF_K, IP_OFFMASK,
+	   ipv6_c + ipv4_c - 1, 0);
+
+  /*
+   * calculate the length of the IP header so that we can then
+   * calculate the distance of the transport header into the packet
+   */
+  if(udp4_portc > 0 || tcp4_portc > 0)
+    bpf_stmt(insns, len, &off, BPF_LDX+BPF_MSH+BPF_B, ip_off);
+
+  /* load the protocol type into the accumulator */
+  bpf_stmt(insns, len, &off, BPF_LD+BPF_ABS+BPF_B, ip_off+9);
+
+  /* if it is ICMP, which is specific to IPv4, pass it */
+  bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, IPPROTO_ICMP,
+	   len - off - 2,
+	   udp4_portc > 0 || tcp4_portc > 0 ? 0 : len - off - 3);
+
+    if(udp4_portc > 0)
+    bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, IPPROTO_UDP,
+	     tcp4_portc > 0 ? 1 : 0,
+	     tcp4_portc > 0 ? 0 : len - off - 3);
+
+  if(tcp4_portc > 0)
+    bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, IPPROTO_TCP,
+	     udp4_portc > 0 ? (udp4_portc * 2) + 2 : 0,
+	     len - off - 3);
+
+  if(udp4_portc > 0)
+    {
+      /* check udp4 sport */
+      bpf_stmt(insns, len, &off, BPF_LD+BPF_IND+BPF_H, ip_off + 0);
+      for(i=0; i<udp4_portc; i++)
+	bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, udp4_ports[i],
+		 len - off - 2,
+		 0);
+
+      /* check udp4 dport */
+      bpf_stmt(insns, len, &off, BPF_LD+BPF_IND+BPF_H, ip_off + 2);
+      for(i=0; i<udp4_portc; i++)
+	bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, udp4_ports[i],
+		 len - off - 2,
+		 udp4_portc - i > 1 ? 0 : len - off - 3);
+    }
+
+  if(tcp4_portc > 0)
+    {
+      /* check tcp4 sport */
+      bpf_stmt(insns, len, &off, BPF_LD+BPF_IND+BPF_H, ip_off + 0);
+      for(i=0; i<tcp4_portc; i++)
+	bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, tcp4_ports[i],
+		 len - off - 2,
+		 0);
+
+      /* check tcp4 dport */
+      bpf_stmt(insns, len, &off, BPF_LD+BPF_IND+BPF_H, ip_off + 2);
+      for(i=0; i<tcp4_portc; i++)
+	bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, tcp4_ports[i],
+		 len - off - 2,
+		 tcp4_portc - i > 1 ? 0 : len - off - 3);
+    }
+
+  /* load the IPv6 protocol type into the accumulator */
+  bpf_stmt(insns, len, &off, BPF_LD+BPF_ABS+BPF_B, ip_off+6);
+
+  /* if it is ICMP, which is specific to IPv6, pass it */
+  bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, IPPROTO_ICMPV6,
+	   len - off - 2, 0);
+
+  if(udp6_portc > 0)
+    bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, IPPROTO_UDP,
+	     4 + (tcp6_portc > 0 ? 1 : 0),
+	     0);
+
+  if(tcp6_portc > 0)
+    bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, IPPROTO_TCP,
+	     4 + (udp6_portc > 0 ? (udp6_portc * 2) + 2 : 0),
+	     0);
+
+  /* just pass these packets through */
+  bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, IPPROTO_FRAGMENT,
+	   len - off - 2, 0);
+  bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, IPPROTO_HOPOPTS,
+	   len - off - 2, 0);
+  bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, IPPROTO_DSTOPTS,
+	   len - off - 2, 0);
+  bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, IPPROTO_ROUTING,
+	   len - off - 2, len - off - 3);
+
+  if(udp6_portc > 0)
+    {
+      /* check udp6 sport */
+      bpf_stmt(insns, len, &off, BPF_LD+BPF_ABS+BPF_H, ip_off + 40);
+      for(i=0; i<udp6_portc; i++)
+	bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, udp6_ports[i],
+		 len - off - 2,
+		 0);
+
+      /* check udp6 dport */
+      bpf_stmt(insns, len, &off, BPF_LD+BPF_ABS+BPF_H, ip_off + 42);
+      for(i=0; i<udp6_portc; i++)
+	bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, udp6_ports[i],
+		 len - off - 2,
+		 udp6_portc - i > 1 ? 0 : len - off - 3);
+    }
+
+  if(tcp6_portc > 0)
+    {
+      /* check tcp6 sport */
+      bpf_stmt(insns, len, &off, BPF_LD+BPF_ABS+BPF_H, ip_off + 40);
+      for(i=0; i<tcp6_portc; i++)
+	bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, tcp6_ports[i],
+		 len - off - 2,
+		 0);
+
+      /* check tcp6 dport */
+      bpf_stmt(insns, len, &off, BPF_LD+BPF_ABS+BPF_H, ip_off + 42);
+      for(i=0; i<tcp6_portc; i++)
+	bpf_jump(insns, len, &off, BPF_JMP+BPF_JEQ+BPF_K, tcp6_ports[i],
+		 len - off - 2,
+		 tcp6_portc - i > 1 ? 0 : len - off - 3);
+    }
+
+  /* branch targets to cause the packet to pass/fail the filter */
+  bpf_stmt(insns, len, &off, BPF_RET+BPF_K, 0);
+  bpf_stmt(insns, len, &off, BPF_RET+BPF_K, 65535);
+
+#ifdef HAVE_BPF
+  prog->bf_len = len;
+  prog->bf_insns = insns;
+#else
+  prog->len = len;
+  prog->filter = insns;
 #endif
+
+  return 0;
+}
+#endif /* __linux__ or BIOCSETFNR */
+
+int scamper_dl_filter(const scamper_dl_t *node,
+		      const uint16_t *ports, size_t portc)
+{
+#if defined(HAVE_BPF)
+  struct bpf_program prog;
+  struct bpf_insn open[1];
+#else
+  struct sock_fprog prog;
+  struct sock_filter open[1];
+#endif
+  int rc, fd;
+  size_t off = 0;
+
+#if defined(__linux__) || defined(BIOCSETFNR)
+  int dyn = scamper_option_dynfilter();
+#endif
+
+  memset(&prog, 0, sizeof(prog));
+  bpf_stmt(open, 1, &off, BPF_RET+BPF_K, 65535);
+
+  /* fallback to an open filter */
+  if(ports == NULL
+#if defined(__linux__) || defined(BIOCSETFNR)
+     || dyn == 0 || dl_filter_compile(node, &prog, ports, portc) != 0
+#endif
+     )
+    {
+#ifdef HAVE_BPF
+      prog.bf_insns = open;
+      prog.bf_len = 1;
+#else
+      prog.filter = open;
+      prog.len = 1;
+#endif
+    }
+
+  fd = scamper_fd_fd_get(node->fdn);
+
+#ifdef HAVE_BPF
+#ifndef BIOCSETFNR
+  if((rc = ioctl(fd, BIOCSETF, (caddr_t)&prog)) != -1)
+    rc = 0;
+  else
+    printerror(__func__, "BIOCSETF failed");
+#else
+  if((rc = ioctl(fd, dyn == 0 ? BIOCSETF : BIOCSETFNR, (caddr_t)&prog)) != -1)
+    {
+      rc = 0;
+      scamper_debug(__func__, "filter %d successful", prog.bf_len);
+    }
+  else
+    {
+      if(dyn == 0)
+	printerror(__func__, "BIOCSETF failed");
+      else
+	printerror(__func__, "BIOCSETFNR attempt 1 failed");
+    }
+  if(prog.bf_len > 1)
+    {
+      free(prog.bf_insns);
+      if(rc == -1)
+	{
+	  prog.bf_insns = open;
+	  prog.bf_len = 1;
+	  if((rc = ioctl(fd, BIOCSETFNR, (caddr_t)&prog)) != -1)
+	    {
+	      rc = 0;
+	      scamper_debug(__func__, "installed open filter");
+	    }
+	  else printerror(__func__, "BIOCSETFNR attempt 2 failed");
+	}
+    }
+#endif /* BIOCSETFNR */
+#else
+  if((rc = setsockopt(fd, SOL_SOCKET, SO_ATTACH_FILTER,
+		      (caddr_t)&prog, sizeof(prog))) != -1)
+    {
+      rc = 0;
+      scamper_debug(__func__, "filter %d successful", prog.len);
+    }
+  else printerror(__func__, "SO_ATTACH_FILTER attempt 1 failed");
+
+  if(prog.len > 1)
+    {
+      free(prog.filter);
+      if(rc == -1)
+	{
+	  prog.filter = open;
+	  prog.len = 1;
+	  if((rc = setsockopt(fd, SOL_SOCKET, SO_ATTACH_FILTER,
+			      (caddr_t)&prog, sizeof(prog))) != -1)
+	    {
+	      rc = 0;
+	      scamper_debug(__func__, "installed open filter");
+	    }
+	  else printerror(__func__, "SO_ATTACH_FILTER attempt 2 failed");
+	}
+    }
+#endif
+
+  return rc;
+}
+
+static int dl_filter_init(const scamper_dl_t *node)
+{
+#if defined(__linux__) || defined(BIOCSETFNR)
+  uint16_t *ports = NULL;
+  size_t portc = 0;
+  int rc;
+  if(scamper_option_dynfilter() == 0 ||
+     scamper_fds_sports(&ports, &portc) != 0)
+    goto done;
+  rc = scamper_dl_filter(node, ports, portc);
+  if(ports != NULL)
+    free(ports);
+  return rc;
+ done:
+  /* ports will be null, nothing to free */
+#endif
+  return scamper_dl_filter(node, NULL, 0);
+}
+
+#endif /* HAVE_BPF_FILTER */
 
 int scamper_dl_rec_src(scamper_dl_rec_t *dl, scamper_addr_t *addr)
 {
@@ -2302,6 +2727,12 @@ scamper_dl_t *scamper_dl_state_alloc(scamper_fd_t *fdn)
     }
   dl->fdn = fdn;
 
+  if(scamper_fd_ifindex(fdn, &dl->ifindex) != 0)
+    {
+      printerror_msg(__func__, "could not get ifindex");
+      goto err;
+    }
+
 #if defined(HAVE_BPF)
   if(dl_bpf_node_init(fdn, dl) == -1)
 #elif defined(__linux__)
@@ -2314,7 +2745,7 @@ scamper_dl_t *scamper_dl_state_alloc(scamper_fd_t *fdn)
     }
 
 #if defined(HAVE_BPF_FILTER)
-  dl_filter(dl);
+  dl_filter_init(dl);
 #endif
 
   return dl;
@@ -2324,8 +2755,7 @@ scamper_dl_t *scamper_dl_state_alloc(scamper_fd_t *fdn)
   return NULL;
 }
 
-int scamper_dl_tx(const scamper_dl_t *node,
-		  const uint8_t *pkt, const size_t len)
+int scamper_dl_tx(const scamper_dl_t *node, const uint8_t *pkt, size_t len)
 {
 #if defined(HAVE_BPF)
   if(dl_bpf_tx(node, pkt, len) == -1)
@@ -2352,7 +2782,7 @@ int scamper_dl_tx_type(scamper_dl_t *dl)
  * routine to actually open a datalink.  called by scamper_dl_open below,
  * as well as by the privsep code.
  */
-int scamper_dl_open_fd(const int ifindex)
+int scamper_dl_open_fd(int ifindex)
 {
 #if defined(HAVE_BPF)
   return dl_bpf_open(ifindex);
@@ -2371,27 +2801,19 @@ int scamper_dl_open_fd(const int ifindex)
  * return a file descriptor for the datalink for the interface specified.
  * use privilege separation if required, otherwise open fd directly.
  */
-int scamper_dl_open(const int ifindex)
+int scamper_dl_open(int ifindex)
 {
   int fd = -1;
 
 #ifdef DISABLE_PRIVSEP
 #ifdef HAVE_SETEUID
-  uid_t uid = scamper_getuid();
-  uid_t euid = scamper_geteuid();
-  if(uid != euid && seteuid(euid) != 0)
-    {
-      printerror(__func__, "could not claim euid");
-      return -1;
-    }
+  uid_t uid, euid;
+  if(scamper_seteuid_raise(&uid, &euid) != 0)
+    return -1;
 #endif
   fd = scamper_dl_open_fd(ifindex);
 #ifdef HAVE_SETEUID
-  if(uid != euid && seteuid(uid) != 0)
-    {
-      printerror(__func__, "could not return to uid");
-      exit(-errno);
-    }
+  scamper_seteuid_lower(&uid, &euid);
 #endif
 #else
   fd = scamper_privsep_open_datalink(ifindex);
@@ -2419,44 +2841,14 @@ void scamper_dl_cleanup()
 int scamper_dl_init()
 {
 #if defined(HAVE_BPF)
-  int rc;
-#ifdef HAVE_SETEUID
-  uid_t uid = scamper_getuid();
-  uid_t euid = scamper_geteuid();
-  if(uid != euid && seteuid(euid) != 0)
-    {
-      printerror(__func__, "could not claim euid");
-      return -1;
-    }
-#endif
-  rc = dl_bpf_init();
-#ifdef HAVE_SETEUID
-  if(uid != euid && seteuid(uid) != 0)
-    {
-      printerror(__func__, "could not return to uid");
-      exit(-errno);
-    }
-#endif
-  return rc;
+  return dl_bpf_init();
 #elif defined(__linux__)
-  readbuf_len = 128;
-  if((readbuf = malloc_zero(readbuf_len)) == NULL)
-    {
-      printerror(__func__, "could not malloc readbuf");
-      readbuf_len = 0;
-      return -1;
-    }
+  return dl_linux_init();
 #elif defined(HAVE_DLPI)
-  readbuf_len = 65536; /* magic obtained from pcap-dlpi.c */
-  if((readbuf = malloc_zero(readbuf_len)) == NULL)
-    {
-      printerror(__func__, "could not malloc readbuf");
-      readbuf_len = 0;
-      return -1;
-    }
-#endif
-
+  return dl_dlpi_init()
+#else
   return 0;
+#endif
 }
 
-#endif /* ifndef TEST_DL_PARSE_IP */
+#endif /* ifdef BUILDING_SCAMPER */

--- a/scamper/scamper_dlhdr.h
+++ b/scamper/scamper_dlhdr.h
@@ -1,7 +1,7 @@
 /*
  * scamper_dlhdr.h
  *
- * $Id: scamper_dlhdr.h,v 1.5 2012/04/05 18:00:54 mjl Exp $
+ * $Id: scamper_dlhdr.h,v 1.6 2024/06/30 19:08:57 mjl Exp $
  *
  * Copyright (C) 2003-2006 Matthew Luckie
  * Copyright (C) 2006-2010 The University of Waikato
@@ -24,9 +24,6 @@
 
 #ifndef __SCAMPER_DLHDR_H
 #define __SCAMPER_DLHDR_H
-
-int scamper_dlhdr_init(void);
-void scamper_dlhdr_cleanup(void);
 
 typedef struct scamper_dlhdr scamper_dlhdr_t;
 

--- a/scamper/scamper_fds.c
+++ b/scamper/scamper_fds.c
@@ -1,7 +1,7 @@
 /*
  * scamper_fds: manage events and file descriptors
  *
- * $Id: scamper_fds.c,v 1.123 2024/02/27 02:39:13 mjl Exp $
+ * $Id: scamper_fds.c,v 1.130 2024/07/15 23:12:44 mjl Exp $
  *
  * Copyright (C) 2004-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -396,6 +396,35 @@ static void fd_refcnt_0(scamper_fd_t *fdn)
 
   return;
 }
+
+#if defined(BUILDING_SCAMPER) && (defined(__linux__) || defined(BIOCSETFNR))
+static void fd_dynfilter(void)
+{
+  dlist_node_t *dn;
+  scamper_fd_t *fdn;
+  uint16_t *sports = NULL;
+  size_t len = 0;
+  int seen = 0;
+
+  for(dn=dlist_head_node(fd_list); dn != NULL; dn=dlist_node_next(dn))
+    {
+      fdn = dlist_node_item(dn);
+      if(fdn->type != SCAMPER_FD_TYPE_DL)
+	continue;
+      if(seen == 0)
+	{
+	  scamper_fds_sports(&sports, &len);
+	  seen = 1;
+	}
+      scamper_dl_filter(fdn->fd_dl, sports, len);
+    }
+
+  if(sports != NULL)
+    free(sports);
+
+  return;
+}
+#endif
 
 static int fd_poll_setlist(void *item, void *param)
 {
@@ -1246,6 +1275,12 @@ static scamper_fd_t *fd_tcp(int type, void *src, uint16_t sport,
     }
 
   scamper_debug(__func__, "fd %d type %s", fdn->fd, fd_tostr(fdn));
+
+#if defined(BUILDING_SCAMPER) && (defined(__linux__) || defined(BIOCSETFNR))
+  if(scamper_option_dynfilter())
+    fd_dynfilter();
+#endif
+
   return fdn;
 
  err:
@@ -1377,6 +1412,13 @@ static scamper_fd_t *fd_udp(int type, void *src, uint16_t sport,
     }
 
   scamper_debug(__func__, "fd %d type %s", fdn->fd, fd_tostr(fdn));
+
+#if defined(BUILDING_SCAMPER) && (defined(__linux__) || defined(BIOCSETFNR))
+  if(scamper_option_dynfilter() &&
+     (fdn->type == SCAMPER_FD_TYPE_UDP4DG || fdn->type == SCAMPER_FD_TYPE_UDP6))
+    fd_dynfilter();
+#endif
+
   return fdn;
 
  err:
@@ -1755,6 +1797,11 @@ scamper_fd_t *scamper_fd_dl(int ifindex)
   SOCKET fd = INVALID_SOCKET;
 #endif
 
+#if defined(BUILDING_SCAMPER) && defined(__linux__)
+  if(scamper_option_dlany() != 0)
+    ifindex = 0;
+#endif
+
   findme.type = SCAMPER_FD_TYPE_DL;
   findme.fd_ifindex = ifindex;
 
@@ -1904,7 +1951,7 @@ int scamper_fd_sport(const scamper_fd_t *fdn, uint16_t *sport)
   if(SCAMPER_FD_HAS_SPORT(fdn) == 0)
     return -1;
   *sport = fdn->fd_sport;
-  return 0;    
+  return 0;
 }
 
 /*
@@ -2043,6 +2090,76 @@ static void cleanup_list(dlist_t *list)
 }
 
 /*
+ * scamper_fds_sports:
+ *
+ * return the list of ports that tcp/udp sockets are bound to.  does
+ * not consider udp4err sockets.
+ *
+ * on return, the first 4 entries of the ports_out array reports how
+ * many udp4, tcp4, udp6, and tcp6 ports are recorded in the array.
+ * the ports are then recorded in the array in that order.  the caller
+ * is responsible for freeing the ports_out array.
+ *
+ */
+int scamper_fds_sports(uint16_t **ports_out, size_t *portc_out)
+{
+  size_t udp4c = 0, udp6c = 0, tcp4c = 0, tcp6c = 0;
+  size_t udp4i, udp6i, tcp4i, tcp6i;
+  scamper_fd_t *fdn;
+  dlist_node_t *dn;
+  uint16_t *ports;
+  size_t portc;
+
+  for(dn=dlist_head_node(fd_list); dn != NULL; dn=dlist_node_next(dn))
+    {
+      fdn = dlist_node_item(dn);
+      switch(fdn->type)
+	{
+	case SCAMPER_FD_TYPE_UDP4DG: udp4c++; break;
+	case SCAMPER_FD_TYPE_UDP6:   udp6c++; break;
+	case SCAMPER_FD_TYPE_TCP4:   tcp4c++; break;
+	case SCAMPER_FD_TYPE_TCP6:   tcp6c++; break;
+	}
+    }
+
+  portc = 4 + udp4c + udp6c + tcp4c + tcp6c;
+  if((ports = malloc(sizeof(uint16_t) * portc)) == NULL)
+    {
+      *ports_out = NULL;
+      *portc_out = 0;
+      return -1;
+    }
+  ports[0] = udp4c; udp4i = 4;
+  ports[1] = tcp4c; tcp4i = udp4i + udp4c;
+  ports[2] = udp6c; udp6i = tcp4i + tcp4c;
+  ports[3] = tcp6c; tcp6i = udp6i + udp6c;
+
+  for(dn=dlist_head_node(fd_list); dn != NULL; dn=dlist_node_next(dn))
+    {
+      fdn = dlist_node_item(dn);
+      switch(fdn->type)
+        {
+        case SCAMPER_FD_TYPE_UDP4DG:
+	  ports[udp4i++] = fdn->fd_sport;
+	  break;
+        case SCAMPER_FD_TYPE_UDP6:
+	  ports[udp6i++] = fdn->fd_sport;
+	  break;
+	case SCAMPER_FD_TYPE_TCP4:
+	  ports[tcp4i++] = fdn->fd_sport;
+	  break;
+        case SCAMPER_FD_TYPE_TCP6:
+	  ports[tcp6i++] = fdn->fd_sport;
+	  break;
+        }
+    }
+
+  *ports_out = ports;
+  *portc_out = portc;
+  return 0;
+}
+
+/*
  * scamper_fds_cleanup
  *
  * tidy up the state allocated to maintain fd records.
@@ -2089,6 +2206,7 @@ void scamper_fds_cleanup()
       free(fd_array);
       fd_array = NULL;
     }
+  fd_array_s = 0;
 
 #ifdef HAVE_POLL
   if(poll_fds != NULL)

--- a/scamper/scamper_fds.h
+++ b/scamper/scamper_fds.h
@@ -1,7 +1,7 @@
 /*
  * scamper_fds: manage events for file descriptors
  *
- * $Id: scamper_fds.h,v 1.32 2024/02/27 01:01:44 mjl Exp $
+ * $Id: scamper_fds.h,v 1.34 2024/07/15 22:08:08 mjl Exp $
  *
  * Copyright (C) 2004-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -114,6 +114,9 @@ scamper_dl_t *scamper_fd_dl_get(const scamper_fd_t *fdn);
 
 /* function to check the status of all file descriptors managed */
 int scamper_fds_poll(struct timeval *timeout);
+
+/* function to obtain source ports held in scamper file descriptors */
+int scamper_fds_sports(uint16_t **ports_out, size_t *portc_out);
 
 /* functions used to initialise or cleanup the fd monitoring state */
 int scamper_fds_init(void);

--- a/scamper/scamper_file.c
+++ b/scamper/scamper_file.c
@@ -1,13 +1,13 @@
 /*
  * scamper_file.c
  *
- * $Id: scamper_file.c,v 1.124 2023/11/22 04:10:09 mjl Exp $
+ * $Id: scamper_file.c,v 1.127 2024/03/21 22:44:03 mjl Exp $
  *
  * Copyright (C) 2004-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
  * Copyright (C) 2012      The Regents of the University of California
  * Copyright (C) 2022-2023 Matthew Luckie
- * Copyright (C) 2023      The Regents of the University of California
+ * Copyright (C) 2023-2024 The Regents of the University of California
  * Author: Matthew Luckie
  *
  * This program is free software; you can redistribute it and/or modify
@@ -967,16 +967,16 @@ static void z_flush(scamper_file_z_t *z, int fd)
     {
       z->s.bzs->next_in = NULL;
       z->s.bzs->avail_in = 0;
-      z->s.bzs->avail_out = sizeof(z->out);
-      z->s.bzs->next_out = (char *)z->out;
       do
 	{
+	  z->s.bzs->avail_out = sizeof(z->out);
+	  z->s.bzs->next_out = (char *)z->out;
 	  rc = BZ2_bzCompress(z->s.bzs, BZ_FINISH);
-	  have = sizeof(z->out) - z->s.bzs->avail_out;
-	  if(have > 0)
+	  if((rc == BZ_FINISH_OK || rc == BZ_STREAM_END) &&
+	     (have = sizeof(z->out) - z->s.bzs->avail_out) > 0)
 	    write_wrap(fd, z->out, NULL, have);
 	}
-      while(rc != BZ_STREAM_END);
+      while(rc == BZ_FINISH_OK);
       return;
     }
 #endif
@@ -986,10 +986,10 @@ static void z_flush(scamper_file_z_t *z, int fd)
     {
       z->s.xzs->next_in = NULL;
       z->s.xzs->avail_in = 0;
-      z->s.xzs->avail_out = sizeof(z->out);
-      z->s.xzs->next_out = z->out;
       do
 	{
+	  z->s.xzs->avail_out = sizeof(z->out);
+	  z->s.xzs->next_out = z->out;
 	  rc = lzma_code(z->s.xzs, LZMA_FINISH);
 	  have = sizeof(z->out) - z->s.xzs->avail_out;
 	  if(have > 0)
@@ -1305,7 +1305,7 @@ static int z_read(scamper_file_t *sf, uint8_t **data, size_t len)
 	  if(z_decompress(sf->z, &have) != 0)
 	    goto err;
 	}
-      while(have == 0 && sf->z->eof == 0);      
+      while(have == 0 && sf->z->eof == 0);
     }
 
   free(tmp);

--- a/scamper/scamper_firewall.c
+++ b/scamper/scamper_firewall.c
@@ -1,7 +1,7 @@
 /*
  * scamper_firewall.c
  *
- * $Id: scamper_firewall.c,v 1.58 2023/09/22 22:02:48 mjl Exp $
+ * $Id: scamper_firewall.c,v 1.59 2024/07/14 10:55:43 mjl Exp $
  *
  * Copyright (C) 2008-2011 The University of Waikato
  * Copyright (C) 2016-2023 Matthew Luckie
@@ -29,7 +29,7 @@
 
 #ifdef HAVE_NETINET_IP_FW_H
 #include <netinet/ip_fw.h>
-#ifdef HAVE_NETINET6_IP_FW_H
+#ifdef HAVE_NETINET6_IP6_FW_H
 #include <netinet6/ip6_fw.h>
 #endif
 #endif

--- a/scamper/scamper_icmp6.c
+++ b/scamper/scamper_icmp6.c
@@ -1,7 +1,7 @@
 /*
  * scamper_icmp6.c
  *
- * $Id: scamper_icmp6.c,v 1.109 2023/08/26 21:25:08 mjl Exp $
+ * $Id: scamper_icmp6.c,v 1.115 2024/07/02 01:11:17 mjl Exp $
  *
  * Copyright (C) 2003-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -34,6 +34,7 @@
 #include "scamper_addr_int.h"
 #include "scamper_task.h"
 #include "scamper_dl.h"
+#include "scamper_dlhdr.h"
 #include "scamper_probe.h"
 #include "scamper_icmp_resp.h"
 #include "scamper_ip6.h"
@@ -191,13 +192,19 @@ int scamper_icmp6_probe(scamper_probe_t *probe)
   icmphdrlen = (1 + 1 + 2 + 2 + 2);
   len = probe->pr_len + icmphdrlen;
 
-  i = probe->pr_ip_ttl;
-  if(setsockopt(probe->pr_fd,
-		IPPROTO_IPV6, IPV6_UNICAST_HOPS, (void *)&i, sizeof(i)) == -1)
+  if(setsockopt_int(probe->pr_fd, IPPROTO_IPV6, IPV6_UNICAST_HOPS, probe->pr_ip_ttl) != 0)
     {
-      printerror(__func__, "could not set hlim to %d", i);
+      printerror(__func__, "could not set hlim to %d", probe->pr_ip_ttl);
       return -1;
     }
+
+#ifdef IPV6_TCLASS
+  if(setsockopt_int(probe->pr_fd, IPPROTO_IPV6, IPV6_TCLASS, probe->pr_ip_tos) != 0)
+    {
+      printerror(__func__, "could not set tclass to %d", probe->pr_ip_tos);
+      return -1;
+    }
+#endif /* IPV6_TCLASS */
 
   if(txbuf_len < len)
     {
@@ -259,20 +266,25 @@ int scamper_icmp6_probe(scamper_probe_t *probe)
  * get details of when the packet was received.
  */
 #ifndef _WIN32 /* windows does not have msghdr struct */
-static void icmp6_recv_ip_outer(int fd, 
+static void icmp6_recv_ip_outer(int fd,
 				struct msghdr *msg,
 #else
-static void icmp6_recv_ip_outer(SOCKET fd, 
+static void icmp6_recv_ip_outer(SOCKET fd,
 #endif
 				scamper_icmp_resp_t *resp,
 				struct icmp6_hdr *icmp,
 				struct sockaddr_in6 *from, size_t size)
 {
   int16_t hlim = -1;
+  int v;
 
 #if (defined(IPV6_HOPLIMIT) || defined(SO_TIMESTAMP)) && !defined(_WIN32)
   /* get the HLIM field of the ICMP6 packet returned */
   struct cmsghdr *cm;
+
+#ifdef IPV6_PKTINFO
+  struct in6_pktinfo *pi;
+#endif
 
   /*
    * RFC 2292:
@@ -285,7 +297,31 @@ static void icmp6_recv_ip_outer(SOCKET fd,
 	{
 #if defined(IPV6_HOPLIMIT)
 	  if(cm->cmsg_level == IPPROTO_IPV6 && cm->cmsg_type == IPV6_HOPLIMIT)
-	    hlim = *((uint8_t *)CMSG_DATA(cm));
+	    {
+	      v = *((int *)CMSG_DATA(cm));
+	      hlim = (uint8_t)v;
+	      goto next;
+	    }
+#endif
+
+#if defined(IPV6_TCLASS)
+	  if(cm->cmsg_level == IPPROTO_IPV6 && cm->cmsg_type == IPV6_TCLASS)
+	    {
+	      v = *((int *)CMSG_DATA(cm));
+	      resp->ir_ip_tos = (uint8_t)v;
+	      resp->ir_flags |= SCAMPER_ICMP_RESP_FLAG_TCLASS;
+	      goto next;
+	    }
+#endif
+
+#if defined(IPV6_PKTINFO)
+	  if(cm->cmsg_level == IPPROTO_IPV6 && cm->cmsg_type == IPV6_PKTINFO)
+	    {
+	      pi = (struct in6_pktinfo *)CMSG_DATA(cm);
+	      resp->ir_ifindex = pi->ipi6_ifindex;
+	      resp->ir_flags |= SCAMPER_ICMP_RESP_FLAG_IFINDEX;
+	      goto next;
+	    }
 #endif
 
 #if defined(SO_TIMESTAMP)
@@ -293,8 +329,11 @@ static void icmp6_recv_ip_outer(SOCKET fd,
 	    {
 	      timeval_cpy(&resp->ir_rx, (struct timeval *)CMSG_DATA(cm));
 	      resp->ir_flags |= SCAMPER_ICMP_RESP_FLAG_KERNRX;
+	      goto next;
 	    }
 #endif
+
+	next:
 	  cm = (struct cmsghdr *)CMSG_NXTHDR(msg, cm);
 	}
     }
@@ -489,6 +528,7 @@ int scamper_icmp6_recv(SOCKET fd, scamper_icmp_resp_t *resp)
       resp->ir_inner_ip_hlim  = ip->ip6_hlim;
       resp->ir_inner_ip_size  = ntohs(ip->ip6_plen) + sizeof(struct ip6_hdr);
       resp->ir_inner_ip_flow  = ntohl(ip->ip6_flow) & 0xfffff;
+      resp->ir_inner_ip_tos   = ((ntohl(ip->ip6_flow) & 0x0ff00000) >> 20);
 
       if(type == ICMP6_PACKET_TOO_BIG)
 	resp->ir_icmp_nhmtu = (ntohl(icmp->icmp6_mtu) % 0xffff);
@@ -560,7 +600,6 @@ SOCKET scamper_icmp6_open(const void *addr)
 #endif
 {
   struct sockaddr_in6 sin6;
-  int opt;
 
 #ifndef _WIN32 /* SOCKET vs int on windows */
   int fd = -1;
@@ -596,23 +635,20 @@ SOCKET scamper_icmp6_open(const void *addr)
   if(socket_isinvalid(fd))
     goto err;
 
-  opt = 65535 + 128;
-  if(setsockopt(fd, SOL_SOCKET, SO_RCVBUF, (void *)&opt, sizeof(opt)) == -1)
+  if(setsockopt_raise(fd, SOL_SOCKET, SO_RCVBUF, 65535 + 128) != 0)
     {
       printerror(__func__, "could not SO_RCVBUF");
       goto err;
     }
 
-  opt = 65535 + 128;
-  if(setsockopt(fd, SOL_SOCKET, SO_SNDBUF, (void *)&opt, sizeof(opt)) == -1)
+  if(setsockopt_raise(fd, SOL_SOCKET, SO_SNDBUF, 65535 + 128) != 0)
     {
       printerror(__func__, "could not SO_SNDBUF");
       return -1;
     }
 
 #if defined(SO_TIMESTAMP)
-  opt = 1;
-  if(setsockopt(fd, SOL_SOCKET, SO_TIMESTAMP, (void *)&opt, sizeof(opt)) == -1)
+  if(setsockopt_int(fd, SOL_SOCKET, SO_TIMESTAMP, 1) != 0)
     {
       printerror(__func__, "could not set SO_TIMESTAMP");
       goto err;
@@ -638,12 +674,16 @@ SOCKET scamper_icmp6_open(const void *addr)
 #endif
 
 #if defined(IPV6_DONTFRAG)
-  opt = 1;
-  if(setsockopt(fd,IPPROTO_IPV6,IPV6_DONTFRAG,(void *)&opt, sizeof(opt)) == -1)
+  if(setsockopt_int(fd, IPPROTO_IPV6, IPV6_DONTFRAG, 1) != 0)
     {
       printerror(__func__, "could not set IPV6_DONTFRAG");
       goto err;
     }
+#endif
+
+#if defined(IPV6_RECVTCLASS)
+  if(setsockopt_int(fd, IPPROTO_IPV6, IPV6_RECVTCLASS, 1) != 0)
+    printerror(__func__, "could not set IPV6_RECVTCLASS");
 #endif
 
   /*
@@ -651,19 +691,24 @@ SOCKET scamper_icmp6_open(const void *addr)
    * so that scamper might be able to infer the length of the reverse path
    */
 #if defined(IPV6_RECVHOPLIMIT)
-  opt = 1;
-  if(setsockopt(fd, IPPROTO_IPV6, IPV6_RECVHOPLIMIT,
-		(void *)&opt, sizeof(opt)) == -1)
-    {
-      printerror(__func__, "could not set IPV6_RECVHOPLIMIT");
-    }
+  if(setsockopt_int(fd, IPPROTO_IPV6, IPV6_RECVHOPLIMIT, 1) != 0)
+    printerror(__func__, "could not set IPV6_RECVHOPLIMIT");
 #elif defined(IPV6_HOPLIMIT)
+  if(setsockopt_int(fd, IPPROTO_IPV6, IPV6_HOPLIMIT, 1) != 0)
+    printerror(__func__, "could not set IPV6_HOPLIMIT");
+#endif
+
+  /*
+   * ask the icmp6 socket to supply the interface on which it receives
+   * a packet.
+   */
+#if defined(IPV6_RECVPKTINFO)
+  if(setsockopt_int(fd, IPPROTO_IPV6, IPV6_RECVPKTINFO, 1) != 0)
+    printerror(__func__, "could not set IPV6_RECVPKTINFO");
+#elif defined(IPV6_PKTINFO)
   opt = 1;
-  if(setsockopt(fd, IPPROTO_IPV6, IPV6_HOPLIMIT,
-		(void *)&opt, sizeof(opt)) == -1)
-    {
-      printerror(__func__, "could not set IPV6_HOPLIMIT");
-    }
+  if(setsockopt_int(fd, IPPROTO_IPV6, IPV6_PKTINFO, 1) != 0)
+    printerror(__func__, "could not set IPV6_PKTINFO");
 #endif
 
   if(addr != NULL)

--- a/scamper/scamper_icmp_resp.c
+++ b/scamper/scamper_icmp_resp.c
@@ -1,7 +1,7 @@
 /*
  * scamper_icmp_resp.c
  *
- * $Id: scamper_icmp_resp.c,v 1.36 2023/05/29 21:22:26 mjl Exp $
+ * $Id: scamper_icmp_resp.c,v 1.37 2024/04/13 22:31:04 mjl Exp $
  *
  * Copyright (C) 2005-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -149,8 +149,8 @@ void scamper_icmp_resp_print(const scamper_icmp_resp_t *ir)
     {
       addr_tostr(AF_INET6, &ir->ir_ip_src.v6, addr, sizeof(addr));
 
-      snprintf(ip, sizeof(ip), "from %s size %d hlim %d", addr,
-	       ir->ir_ip_size, ir->ir_ip_hlim);
+      snprintf(ip, sizeof(ip), "from %s size %d hlim %d tclass 0x%02x", addr,
+	       ir->ir_ip_size, ir->ir_ip_hlim, ir->ir_ip_tos);
 
       switch(ir->ir_icmp_type)
         {
@@ -232,9 +232,9 @@ void scamper_icmp_resp_print(const scamper_icmp_resp_t *ir)
 	{
 	  addr_tostr(AF_INET6, &ir->ir_inner_ip_dst.v6, addr, sizeof(addr));
 	  snprintf(inner_ip, sizeof(inner_ip),
-		   " to %s size %d hlim %d flow 0x%05x", addr,
+		   " to %s size %d hlim %d tclass 0x%02x flow 0x%05x", addr,
 		   ir->ir_inner_ip_size, ir->ir_inner_ip_hlim,
-		   ir->ir_inner_ip_flow);
+		   ir->ir_inner_ip_tos, ir->ir_inner_ip_flow);
 	}
 
       switch(ir->ir_inner_ip_proto)

--- a/scamper/scamper_icmp_resp.h
+++ b/scamper/scamper_icmp_resp.h
@@ -1,7 +1,7 @@
 /*
  * scamper_icmp_resp.h
  *
- * $Id: scamper_icmp_resp.h,v 1.36 2023/08/20 01:21:17 mjl Exp $
+ * $Id: scamper_icmp_resp.h,v 1.38 2024/04/22 05:55:29 mjl Exp $
  *
  * Copyright (C) 2005-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -32,6 +32,8 @@
 #define SCAMPER_ICMP_RESP_FLAG_IPOPT_TS        0x04
 #define SCAMPER_ICMP_RESP_FLAG_INNER_IPOPT_TS  0x08
 #define SCAMPER_ICMP_RESP_FLAG_RXERR           0x10
+#define SCAMPER_ICMP_RESP_FLAG_TCLASS          0x20
+#define SCAMPER_ICMP_RESP_FLAG_IFINDEX         0x40
 
 #define SCAMPER_ICMP_RESP_IS_ECHO_REPLY(ir) ( \
  (ir->ir_af == AF_INET  && ir->ir_icmp_type == 0) || \
@@ -119,6 +121,9 @@ typedef struct scamper_icmp_resp
   /* flags, whose meanings are defined above */
   uint8_t           ir_flags;
 
+  /* the interface the response was received on */
+  unsigned int      ir_ifindex;
+
   /*
    * category 1: the IP header;
    *
@@ -136,7 +141,7 @@ typedef struct scamper_icmp_resp
 
   uint16_t          ir_ip_size;
   uint16_t          ir_ip_id;
-  uint8_t           ir_ip_tos;
+  uint8_t           ir_ip_tos;  /* tclass in IPv6 */
   int16_t           ir_ip_ttl;  /* ir_ip_hlim; -1 if unavailable */
 
   /*

--- a/scamper/scamper_ifname.c
+++ b/scamper/scamper_ifname.c
@@ -1,0 +1,70 @@
+/*
+ * scamper_ifname.c
+ *
+ * $Id: scamper_ifname.c,v 1.1 2024/05/01 07:46:20 mjl Exp $
+ *
+ * Copyright (C) 2024 The Regents of the University of California
+ * Author: Matthew Luckie
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "internal.h"
+
+#include "scamper_ifname.h"
+#include "scamper_ifname_int.h"
+#include "utils.h"
+
+int scamper_ifname_cmp(const scamper_ifname_t *a, const scamper_ifname_t *b)
+{
+  return strcmp(a->ifname, b->ifname);
+}
+
+const char *scamper_ifname_name_get(scamper_ifname_t *ifn)
+{
+  return ifn->ifname;
+}
+
+scamper_ifname_t *scamper_ifname_use(scamper_ifname_t *ifn)
+{
+  ifn->refcnt++;
+  return ifn;
+}
+
+scamper_ifname_t *scamper_ifname_alloc(const char *ifname)
+{
+  scamper_ifname_t *ifn;
+  if((ifn = malloc_zero(sizeof(scamper_ifname_t))) == NULL ||
+     (ifname != NULL && (ifn->ifname = strdup(ifname)) == NULL))
+    goto err;
+  ifn->refcnt = 1;
+  return ifn;
+
+ err:
+  if(ifn != NULL) free(ifn);
+  return NULL;
+}
+
+void scamper_ifname_free(scamper_ifname_t *ifn)
+{
+  if(--ifn->refcnt > 0)
+    return;
+  if(ifn->ifname != NULL) free(ifn->ifname);
+  free(ifn);
+  return;
+}

--- a/scamper/scamper_ifname.h
+++ b/scamper/scamper_ifname.h
@@ -1,0 +1,34 @@
+/*
+ * scamper_ifname.h
+ *
+ * $Id: scamper_ifname.h,v 1.1 2024/05/01 07:46:20 mjl Exp $
+ *
+ * Copyright (C) 2024 The Regents of the University of California
+ * Author: Matthew Luckie
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#ifndef __SCAMPER_IFNAME_H
+#define __SCAMPER_IFNAME_H
+
+typedef struct scamper_ifname scamper_ifname_t;
+
+scamper_ifname_t *scamper_ifname_use(scamper_ifname_t *ifn);
+const char *scamper_ifname_name_get(scamper_ifname_t *ifn);
+void scamper_ifname_free(scamper_ifname_t *ifn);
+int scamper_ifname_cmp(const scamper_ifname_t *a, const scamper_ifname_t *b);
+
+#endif /* __SCAMPER_IFNAME_H */

--- a/scamper/scamper_ifname_int.c
+++ b/scamper/scamper_ifname_int.c
@@ -1,0 +1,174 @@
+/*
+ * scamper_ifname_int.c
+ *
+ * $Id: scamper_ifname_int.c,v 1.2 2024/05/02 03:09:55 mjl Exp $
+ *
+ * Copyright (C) 2024 The Regents of the University of California
+ * Author: Matthew Luckie
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "internal.h"
+
+#include "scamper_ifname.h"
+#include "scamper_ifname_int.h"
+#include "scamper_debug.h"
+
+#include "mjl_list.h"
+#include "mjl_splaytree.h"
+
+#include "utils.h"
+
+static splaytree_t *ifni_tree;
+static dlist_t     *ifni_list;
+
+typedef struct ifname_int
+{
+  unsigned int          ifindex;   /* the ifindex for the name */
+  struct timeval        check;     /* when to recheck ifname (2 secs) */
+  struct timeval        expire;    /* when to expire entry   (10 secs) */
+  splaytree_node_t     *tree_node; /* tree node in ifni_tree */
+  dlist_node_t         *list_node; /* list node in ifni_list */
+  scamper_ifname_t     *ifn;       /* the actual ifn */
+} ifname_int_t;
+
+static int ifname_int_cmp(const ifname_int_t *a, const ifname_int_t *b)
+{
+  if(a->ifindex < b->ifindex) return -1;
+  if(a->ifindex > b->ifindex) return  1;
+  return 0;
+}
+
+static void ifname_int_free(ifname_int_t *ifni)
+{
+  if(ifni->ifn != NULL)
+    scamper_ifname_free(ifni->ifn);
+  if(ifni->tree_node != NULL)
+    splaytree_remove_node(ifni_tree, ifni->tree_node);
+  if(ifni->list_node != NULL)
+    dlist_node_pop(ifni_list, ifni->list_node);
+  free(ifni);
+  return;
+}
+
+scamper_ifname_t *scamper_ifname_int_get(unsigned int ifindex,
+					 const struct timeval *now)
+{
+  ifname_int_t *ifni = NULL, *ptr, fm;
+  scamper_ifname_t *ifn = NULL;
+  dlist_node_t *dn;
+  char ifname[IFNAMSIZ];
+  int push = 0;
+
+  /*
+   * do we have an entry that we've checked in the past couple of seconds?
+   * if so, use it.
+   */
+  fm.ifindex = ifindex;
+  if((ifni = splaytree_find(ifni_tree, &fm)) != NULL &&
+     (now == NULL || timeval_cmp(now, &ifni->check) <= 0))
+    return scamper_ifname_use(ifni->ifn);
+
+  /* get the name for the corresponding interface */
+  if(if_indextoname(ifindex, ifname) == NULL)
+    return NULL;
+
+  /* if the name is the same, then the expire time was reached.  update it */
+  if(ifni != NULL && strcmp(ifname, ifni->ifn->ifname) == 0)
+    {
+      push = 1;
+      goto done;
+    }
+
+  /* the name has changed for the ifindex, so remove our copy */
+  if(ifni != NULL)
+    ifname_int_free(ifni);
+
+  /* new ifname */
+  if((ifni = malloc_zero(sizeof(ifname_int_t))) == NULL ||
+     (ifn = scamper_ifname_alloc(ifname)) == NULL)
+    goto err;
+  ifni->ifindex = ifindex;
+  if((ifni->tree_node = splaytree_insert(ifni_tree, ifni)) == NULL ||
+     (ifni->list_node = dlist_tail_push(ifni_list, ifni)) == NULL)
+    goto err;
+  ifni->ifn = ifn; ifn = NULL;
+
+ done:
+  if(push != 0)
+    dlist_node_tail_push(ifni_list, ifni->list_node);
+  if(now != NULL)
+    timeval_cpy(&ifni->expire, now);
+  else
+    gettimeofday_wrap(&ifni->expire);
+  timeval_cpy(&ifni->check, &ifni->expire);
+  now = &ifni->expire;
+
+  /* expire old entries */
+  dn = dlist_head_node(ifni_list);
+  while(dn != NULL)
+    {
+      ptr = dlist_node_item(dn);
+      dn = dlist_node_next(dn);
+      if(ptr != ifni && timeval_cmp(&ptr->expire, now) < 0)
+	ifname_int_free(ptr);
+    }
+
+  /* update the re-check and expiry times */
+  ifni->check.tv_sec += 2;
+  ifni->expire.tv_sec += 10;
+  return scamper_ifname_use(ifni->ifn);
+
+ err:
+  if(ifn != NULL) scamper_ifname_free(ifn);
+  if(ifni != NULL) ifname_int_free(ifni);
+  return NULL;
+}
+
+int scamper_ifname_int_init(void)
+{
+  if((ifni_tree = splaytree_alloc((splaytree_cmp_t)ifname_int_cmp)) == NULL ||
+     (ifni_list = dlist_alloc()) == NULL)
+    return -1;
+  return 0;
+}
+
+void scamper_ifname_int_cleanup(void)
+{
+  ifname_int_t *ifni;
+
+  if(ifni_list != NULL)
+    {
+      while((ifni = dlist_head_pop(ifni_list)) != NULL)
+	{
+	  ifni->list_node = NULL;
+	  ifname_int_free(ifni);
+	}
+      dlist_free(ifni_list);
+      ifni_list = NULL;
+    }
+
+  if(ifni_tree != NULL)
+    {
+      splaytree_free(ifni_tree, NULL);
+      ifni_tree = NULL;
+    }
+
+  return;
+}

--- a/scamper/scamper_ifname_int.h
+++ b/scamper/scamper_ifname_int.h
@@ -1,0 +1,41 @@
+/*
+ * scamper_ifname_int.h
+ *
+ * $Id: scamper_ifname_int.h,v 1.1 2024/05/01 07:46:20 mjl Exp $
+ *
+ * Copyright (C) 2024 The Regents of the University of California
+ * Author: Matthew Luckie
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#ifndef __SCAMPER_IFNAME_INT_H
+#define __SCAMPER_IFNAME_INT_H
+
+struct scamper_ifname
+{
+  char           *ifname;
+  int             refcnt;
+};
+
+scamper_ifname_t *scamper_ifname_alloc(const char *ifname);
+
+scamper_ifname_t *scamper_ifname_int_get(unsigned int ifindex,
+					 const struct timeval *now);
+
+int scamper_ifname_int_init(void);
+void scamper_ifname_int_cleanup(void);
+
+#endif /* __SCAMPER_IFNAME_INT_H */

--- a/scamper/scamper_ip4.c
+++ b/scamper/scamper_ip4.c
@@ -1,7 +1,7 @@
 /*
  * scamper_ip4.c
  *
- * $Id: scamper_ip4.c,v 1.24 2023/08/26 21:25:08 mjl Exp $
+ * $Id: scamper_ip4.c,v 1.26 2024/07/02 01:11:17 mjl Exp $
  *
  * Copyright (C) 2009-2011 The University of Waikato
  * Copyright (C) 2023      The Regents of the University of California
@@ -33,6 +33,7 @@
 #include "scamper_addr.h"
 #include "scamper_addr_int.h"
 #include "scamper_dl.h"
+#include "scamper_dlhdr.h"
 #include "scamper_probe.h"
 #include "scamper_ip4.h"
 #include "scamper_tcp4.h"
@@ -46,8 +47,6 @@ int scamper_ip4_openraw_fd(void)
 SOCKET scamper_ip4_openraw_fd(void)
 #endif
 {
-  int hdr;
-
 #ifndef _WIN32 /* SOCKET vs int on windows */
   int fd;
 #else
@@ -60,8 +59,7 @@ SOCKET scamper_ip4_openraw_fd(void)
       printerror(__func__, "could not open socket");
       goto err;
     }
-  hdr = 1;
-  if(setsockopt(fd, IPPROTO_IP, IP_HDRINCL, (void *)&hdr, sizeof(hdr)) == -1)
+  if(setsockopt_int(fd, IPPROTO_IP, IP_HDRINCL, 1) != 0)
     {
       printerror(__func__, "could not IP_HDRINCL");
       goto err;

--- a/scamper/scamper_ip6.c
+++ b/scamper/scamper_ip6.c
@@ -1,7 +1,7 @@
 /*
  * scamper_ip6.c
  *
- * $Id: scamper_ip6.c,v 1.22 2023/05/29 21:22:26 mjl Exp $
+ * $Id: scamper_ip6.c,v 1.23 2024/07/02 01:11:17 mjl Exp $
  *
  * Copyright (C) 2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -31,6 +31,7 @@
 #include "scamper_addr.h"
 #include "scamper_addr_int.h"
 #include "scamper_dl.h"
+#include "scamper_dlhdr.h"
 #include "scamper_probe.h"
 #include "scamper_ip6.h"
 

--- a/scamper/scamper_probe.c
+++ b/scamper/scamper_probe.c
@@ -1,7 +1,7 @@
 /*
  * scamper_probe.c
  *
- * $Id: scamper_probe.c,v 1.83 2024/02/28 20:33:41 mjl Exp $
+ * $Id: scamper_probe.c,v 1.85 2024/07/02 01:11:17 mjl Exp $
  *
  * Copyright (C) 2005-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -34,6 +34,7 @@
 #include "scamper_addr.h"
 #include "scamper_addr_int.h"
 #include "scamper_dl.h"
+#include "scamper_dlhdr.h"
 #include "scamper_fds.h"
 #include "scamper_rtsock.h"
 #include "scamper_task.h"
@@ -330,8 +331,7 @@ static scamper_probe_t *probe_dup(scamper_probe_t *pr)
     goto err;
 
   pd->pr_dl = NULL;
-  pd->pr_dl_buf = NULL;
-  pd->pr_dl_len = 0;
+  pd->pr_dlhdr = NULL;
   pd->pr_ipopts = NULL;
   pd->pr_data = NULL;
   if(pr->pr_ip_src != NULL)
@@ -506,7 +506,7 @@ static int probe_dl_tx(probe_state_t *pt)
       pt->error = EINVAL;
       return -1;
     }
-  
+
   if(pt->buf == pktbuf)
     gettimeofday_wrap(&pt->tv);
   dl = scamper_fd_dl_get(fd);
@@ -908,7 +908,8 @@ int scamper_probe(scamper_probe_t *probe)
   int (*send_func)(scamper_probe_t *) = NULL;
   int (*build_func)(scamper_probe_t *, uint8_t *, size_t *) = NULL;
   size_t pad, len;
-  uint8_t *buf;
+  uint8_t *buf, *dl_buf;
+  uint16_t dl_len;
 
   probe->pr_errno = 0;
   probe_print(probe);
@@ -981,22 +982,24 @@ int scamper_probe(scamper_probe_t *probe)
    * bytes to put at the front of the packet buffer so that the IP layer
    * is properly aligned for the architecture
    */
-  pad = PAD(probe->pr_dl_len);
-  if(pad + probe->pr_dl_len >= pktbuf_len)
+  dl_buf = probe->pr_dlhdr->buf;
+  dl_len = probe->pr_dlhdr->len;
+  pad = PAD(dl_len);
+  if(pad + dl_len >= pktbuf_len)
     len = 0;
   else
-    len = pktbuf_len - pad - probe->pr_dl_len;
+    len = pktbuf_len - pad - dl_len;
 
   /*
    * try building the probe.  if it returns -1, then hopefully the len field
    * will supply a clue as to what it should be
    */
-  if(build_func(probe, pktbuf + pad + probe->pr_dl_len, &len) != 0)
+  if(build_func(probe, pktbuf + pad + dl_len, &len) != 0)
     {
-      assert(pktbuf_len < pad + probe->pr_dl_len + len);
+      assert(pktbuf_len < pad + dl_len + len);
 
       /* reallocate the packet buffer */
-      len += pad + probe->pr_dl_len;
+      len += pad + dl_len;
       if((buf = realloc(pktbuf, len)) == NULL)
 	{
 	  probe->pr_errno = errno;
@@ -1006,8 +1009,8 @@ int scamper_probe(scamper_probe_t *probe)
       pktbuf     = buf;
       pktbuf_len = len;
 
-      len = pktbuf_len - pad - probe->pr_dl_len;
-      if(build_func(probe, pktbuf + pad + probe->pr_dl_len, &len) != 0)
+      len = pktbuf_len - pad - dl_len;
+      if(build_func(probe, pktbuf + pad + dl_len, &len) != 0)
 	{
 	  probe->pr_errno = EINVAL;
 	  return -1;
@@ -1015,11 +1018,11 @@ int scamper_probe(scamper_probe_t *probe)
     }
 
   /* add the datalink header size back to the length field */
-  len += probe->pr_dl_len;
+  len += dl_len;
 
   /* pre-pend the datalink header, if there is one */
-  if(probe->pr_dl_len > 0)
-    memcpy(pktbuf+pad, probe->pr_dl_buf, probe->pr_dl_len);
+  if(dl_len > 0)
+    memcpy(pktbuf+pad, dl_buf, dl_len);
 
   gettimeofday_wrap(&probe->pr_tx);
   if(scamper_dl_tx(probe->pr_dl, pktbuf+pad, len) == -1)
@@ -1028,8 +1031,8 @@ int scamper_probe(scamper_probe_t *probe)
       return -1;
     }
 
-  probe->pr_tx_raw = pktbuf + pad + probe->pr_dl_len;
-  probe->pr_tx_rawlen = len - probe->pr_dl_len;
+  probe->pr_tx_raw = pktbuf + pad + dl_len;
+  probe->pr_tx_rawlen = len - dl_len;
   return 0;
 }
 

--- a/scamper/scamper_probe.h
+++ b/scamper/scamper_probe.h
@@ -1,7 +1,7 @@
 /*
  * scamper_probe.h
  *
- * $Id: scamper_probe.h,v 1.48 2023/08/20 01:21:17 mjl Exp $
+ * $Id: scamper_probe.h,v 1.49 2024/07/02 01:11:17 mjl Exp $
  *
  * Copyright (C) 2005-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -122,8 +122,7 @@ typedef struct scamper_probe
   SOCKET                 pr_fd;
 #endif
   scamper_dl_t          *pr_dl;
-  uint8_t               *pr_dl_buf;
-  uint16_t               pr_dl_len;
+  scamper_dlhdr_t       *pr_dlhdr;
 
   /* flags set on input */
   uint16_t               pr_flags;

--- a/scamper/scamper_source_file.c
+++ b/scamper/scamper_source_file.c
@@ -1,7 +1,7 @@
 /*
  * scamper_source_file.c
  *
- * $Id: scamper_source_file.c,v 1.32 2023/08/26 21:25:08 mjl Exp $
+ * $Id: scamper_source_file.c,v 1.33 2024/06/10 03:28:08 mjl Exp $
  *
  * Copyright (C) 2004-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -433,7 +433,6 @@ int scamper_source_file_update(scamper_source_t *source,
 			       const int *autoreload, const int *cycles)
 {
   scamper_source_file_t *ssf;
-  scamper_source_event_t sse;
 
   if(scamper_source_gettype(source) != SCAMPER_SOURCE_TYPE_FILE ||
      (ssf = (scamper_source_file_t *)scamper_source_getdata(source)) == NULL)
@@ -441,26 +440,11 @@ int scamper_source_file_update(scamper_source_t *source,
       return -1;
     }
 
-  memset(&sse, 0, sizeof(sse));
-
   if(autoreload != NULL)
-    {
-      sse.sse_update_flags |= 0x01;
-      sse.sse_update_autoreload = *autoreload;
-      ssf->autoreload = *autoreload;
-    }
+    ssf->autoreload = *autoreload;
 
   if(cycles != NULL)
-    {
-      sse.sse_update_flags |= 0x02;
-      sse.sse_update_cycles = *cycles;
-      ssf->cycles = *cycles;
-    }
-
-  if(sse.sse_update_flags != 0)
-    {
-      scamper_source_event_post(source, SCAMPER_SOURCE_EVENT_UPDATE, &sse);
-    }
+    ssf->cycles = *cycles;
 
   return 0;
 }

--- a/scamper/scamper_sources.h
+++ b/scamper/scamper_sources.h
@@ -1,7 +1,7 @@
 /*
  * scamper_source
  *
- * $Id: scamper_sources.h,v 1.18 2024/02/12 20:35:36 mjl Exp $
+ * $Id: scamper_sources.h,v 1.19 2024/06/10 03:28:08 mjl Exp $
  *
  * Copyright (C) 2004-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -131,60 +131,5 @@ void scamper_sources_foreach(void *p, int (*func)(void *, scamper_source_t *));
 void scamper_sources_empty(void);
 int scamper_sources_init(void);
 void scamper_sources_cleanup(void);
-
-/*
- * interface to observe source events.
- *
- *
- */
-typedef struct scamper_source_event
-{
-  scamper_source_t *source;
-  time_t            sec;
-  int               event;
-
-#define SCAMPER_SOURCE_EVENT_ADD     0x01
-#define SCAMPER_SOURCE_EVENT_UPDATE  0x02
-#define SCAMPER_SOURCE_EVENT_CYCLE   0x03
-#define SCAMPER_SOURCE_EVENT_DELETE  0x04
-#define SCAMPER_SOURCE_EVENT_FINISH  0x05
-
-  union
-  {
-
-    struct sse_update
-    {
-      uint8_t flags;  /* 0x01 == autoreload, 0x02 == cycles, 0x03 = priority */
-      int     autoreload;
-      int     cycles;
-      int     priority;
-    } sseu_update;
-
-#define sse_update_flags       sse_un.sseu_update.flags
-#define sse_update_autoreload  sse_un.sseu_update.autoreload
-#define sse_update_cycles      sse_un.sseu_update.cycles
-#define sse_update_priority    sse_un.sseu_update.priority
-
-    struct sse_cycle
-    {
-      int     cycle_id;
-    } sseu_cycle;
-
-#define sse_cycle_cycle_id     sse_un.sseu_cycle.cycle_id
-
-  } sse_un;
-
-} scamper_source_event_t;
-
-typedef struct scamper_source_observer scamper_source_observer_t;
-
-typedef void (*scamper_source_eventf_t)(const scamper_source_event_t *sse,
-					void *param);
-scamper_source_observer_t *scamper_sources_observe(scamper_source_eventf_t cb,
-						   void *param);
-void scamper_sources_unobserve(scamper_source_observer_t *observer);
-
-void scamper_source_event_post(scamper_source_t *source, int type,
-			       scamper_source_event_t *ev);
 
 #endif /* __SCAMPER_SOURCE_H */

--- a/scamper/scamper_task.c
+++ b/scamper/scamper_task.c
@@ -1,7 +1,7 @@
 /*
  * scamper_task.c
  *
- * $Id: scamper_task.c,v 1.87 2024/02/27 01:01:44 mjl Exp $
+ * $Id: scamper_task.c,v 1.88 2024/07/14 05:02:02 mjl Exp $
  *
  * Copyright (C) 2005-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -238,9 +238,16 @@ static void tx_ip_check(scamper_dl_rec_t *dl)
   else if(SCAMPER_DL_IS_TCP(dl))
     {
       if((dl->dl_tcp_flags & TH_SYN) && (dl->dl_tcp_flags & TH_ACK) == 0)
-	addr.addr = dl->dl_ip_dst;
+	{
+	  addr.addr = dl->dl_ip_dst;
+	}
       else
-	addr.addr = dl->dl_ip_src;
+	{
+	  addr.addr = dl->dl_ip_src;
+	  addr2buf.type = addr.type;
+	  addr2buf.addr = dl->dl_ip_dst;
+	  addr2 = &addr2buf;
+	}
     }
   else if(SCAMPER_DL_IS_ICMP(dl))
     {
@@ -248,11 +255,9 @@ static void tx_ip_check(scamper_dl_rec_t *dl)
 	addr.addr = dl->dl_ip_dst;
       else if(SCAMPER_DL_IS_ICMP_ECHO_REPLY(dl))
 	addr.addr = dl->dl_ip_src;
-      else if(SCAMPER_DL_IS_ICMP_TTL_EXP(dl))
-	addr.addr = dl->dl_icmp_ip_dst;
-      else if(SCAMPER_DL_IS_ICMP_UNREACH(dl))
-	addr.addr = dl->dl_icmp_ip_dst;
-      else if(SCAMPER_DL_IS_ICMP_PACKET_TOO_BIG(dl))
+      else if(SCAMPER_DL_IS_ICMP_TTL_EXP(dl) ||
+	      SCAMPER_DL_IS_ICMP_UNREACH(dl) ||
+	      SCAMPER_DL_IS_ICMP_PACKET_TOO_BIG(dl))
 	addr.addr = dl->dl_icmp_ip_dst;
       else
 	return;
@@ -261,7 +266,8 @@ static void tx_ip_check(scamper_dl_rec_t *dl)
     {
       addr.addr = dl->dl_ip_dst;
       addr2buf.type = addr.type;
-      addr2buf.addr = dl->dl_ip_src; addr2 = &addr2buf;
+      addr2buf.addr = dl->dl_ip_src;
+      addr2 = &addr2buf;
     }
   else
     {

--- a/scamper/scamper_tcp4.c
+++ b/scamper/scamper_tcp4.c
@@ -1,7 +1,7 @@
 /*
  * scamper_tcp4.c
  *
- * $Id: scamper_tcp4.c,v 1.64 2023/08/20 01:21:17 mjl Exp $
+ * $Id: scamper_tcp4.c,v 1.66 2024/07/02 01:11:17 mjl Exp $
  *
  * Copyright (C) 2005-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -32,6 +32,7 @@
 #include "scamper_addr.h"
 #include "scamper_addr_int.h"
 #include "scamper_dl.h"
+#include "scamper_dlhdr.h"
 #include "scamper_probe.h"
 #include "scamper_ip4.h"
 #include "scamper_tcp4.h"
@@ -363,7 +364,6 @@ SOCKET scamper_tcp4_open(const void *addr, int sport)
 {
   struct sockaddr_in sin4;
   char tmp[32];
-  int opt;
 
 #ifndef _WIN32 /* SOCKET vs int on windows */
   int fd = -1;
@@ -378,15 +378,13 @@ SOCKET scamper_tcp4_open(const void *addr, int sport)
       goto err;
     }
 
-  opt = 1;
-  if(setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (void *)&opt, sizeof(opt)) != 0)
+  if(setsockopt_int(fd, SOL_SOCKET, SO_REUSEADDR, 1) != 0)
     {
       printerror(__func__, "could not set SO_REUSEADDR");
       goto err;
     }
 
-  opt = 65535 + 128;
-  if(setsockopt(fd, SOL_SOCKET, SO_SNDBUF, (void *)&opt, sizeof(opt)) != 0)
+  if(setsockopt_raise(fd, SOL_SOCKET, SO_SNDBUF, 65535 + 128) != 0)
     {
       printerror(__func__, "could not set SO_SNDBUF");
       return -1;

--- a/scamper/scamper_tcp6.c
+++ b/scamper/scamper_tcp6.c
@@ -1,7 +1,7 @@
 /*
  * scamper_tcp6.c
  *
- * $Id: scamper_tcp6.c,v 1.38 2023/08/20 01:21:17 mjl Exp $
+ * $Id: scamper_tcp6.c,v 1.40 2024/07/02 01:11:17 mjl Exp $
  *
  * Copyright (C) 2006      Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -31,6 +31,7 @@
 
 #include "scamper_addr.h"
 #include "scamper_dl.h"
+#include "scamper_dlhdr.h"
 #include "scamper_probe.h"
 #include "scamper_ip6.h"
 #include "scamper_tcp6.h"
@@ -296,10 +297,6 @@ SOCKET scamper_tcp6_open(const void *addr, int sport)
   SOCKET fd = INVALID_SOCKET;
 #endif
 
-#ifdef IPV6_V6ONLY
-  int opt;
-#endif
-
   fd = socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
   if(socket_isinvalid(fd))
     {
@@ -308,8 +305,7 @@ SOCKET scamper_tcp6_open(const void *addr, int sport)
     }
 
 #ifdef IPV6_V6ONLY
-  opt = 1;
-  if(setsockopt(fd,IPPROTO_IPV6,IPV6_V6ONLY, (void *)&opt,sizeof(opt)) == -1)
+  if(setsockopt_int(fd, IPPROTO_IPV6, IPV6_V6ONLY, 1) != 0)
     {
       printerror(__func__, "could not set IPV6_V6ONLY");
       goto err;

--- a/scamper/sniff/scamper_sniff_cmd.c
+++ b/scamper/sniff/scamper_sniff_cmd.c
@@ -1,7 +1,7 @@
 /*
  * scamper_sniff_do.c
  *
- * $Id: scamper_sniff_cmd.c,v 1.5 2024/02/14 23:48:21 mjl Exp $
+ * $Id: scamper_sniff_cmd.c,v 1.6 2024/05/02 02:33:38 mjl Exp $
  *
  * Copyright (C) 2011      The University of Waikato
  * Copyright (C) 2022-2023 Matthew Luckie
@@ -181,9 +181,8 @@ void *scamper_do_sniff_alloc(char *str, char *errbuf, size_t errlen)
 	 sniff_arg_param_validate(opt->id, opt->str, &tmp,
 				  buf, sizeof(buf)) != 0)
 	{
-	  snprintf(errbuf, errlen, "-%c %s failed: %s",
-		   scamper_options_id2c(opts, opts_cnt, opt->id),
-		   opt->str, buf);
+	  snprintf(errbuf, errlen, "-%c failed: %s",
+		   scamper_options_id2c(opts, opts_cnt, opt->id), buf);
 	  goto err;
 	}
 

--- a/scamper/sting/scamper_sting_cmd.c
+++ b/scamper/sting/scamper_sting_cmd.c
@@ -1,7 +1,7 @@
 /*
  * scamper_sting_cmd.c
  *
- * $Id: scamper_sting_cmd.c,v 1.6 2024/02/15 00:59:09 mjl Exp $
+ * $Id: scamper_sting_cmd.c,v 1.7 2024/05/02 02:33:38 mjl Exp $
  *
  * Copyright (C) 2008-2011 The University of Waikato
  * Copyright (C) 2012      The Regents of the University of California
@@ -292,9 +292,8 @@ void *scamper_do_sting_alloc(char *str, char *errbuf, size_t errlen)
 	 sting_arg_param_validate(opt->id, opt->str, &tmp,
 				  buf, sizeof(buf)) != 0)
 	{
-	  snprintf(errbuf, errlen, "-%c %s failed: %s",
-		   scamper_options_id2c(opts, opts_cnt, opt->id),
-		   opt->str, buf);
+	  snprintf(errbuf, errlen, "-%c failed: %s",
+		   scamper_options_id2c(opts, opts_cnt, opt->id), buf);
 	  goto err;
 	}
 

--- a/scamper/sting/scamper_sting_do.c
+++ b/scamper/sting/scamper_sting_do.c
@@ -1,7 +1,7 @@
 /*
  * scamper_do_sting.c
  *
- * $Id: scamper_sting_do.c,v 1.59 2024/02/27 03:34:02 mjl Exp $
+ * $Id: scamper_sting_do.c,v 1.60 2024/07/02 01:11:17 mjl Exp $
  *
  * Copyright (C) 2008-2011 The University of Waikato
  * Copyright (C) 2012      The Regents of the University of California
@@ -603,8 +603,7 @@ static void do_sting_probe(scamper_task_t *task)
 
   memset(&probe, 0, sizeof(probe));
   probe.pr_dl        = scamper_fd_dl_get(state->dl);
-  probe.pr_dl_buf    = state->dlhdr->buf;
-  probe.pr_dl_len    = state->dlhdr->len;
+  probe.pr_dlhdr     = state->dlhdr;
   probe.pr_ip_src    = sting->src;
   probe.pr_ip_dst    = sting->dst;
   probe.pr_ip_ttl    = 255;

--- a/scamper/tbit/scamper_tbit.h
+++ b/scamper/tbit/scamper_tbit.h
@@ -1,7 +1,7 @@
 /*
  * scamper_tbit.h
  *
- * $Id: scamper_tbit.h,v 1.65 2023/08/08 06:19:31 mjl Exp $
+ * $Id: scamper_tbit.h,v 1.66 2024/05/20 04:52:37 mjl Exp $
  *
  * Copyright (C) 2009-2010 Ben Stasiewicz
  * Copyright (C) 2010-2011 University of Waikato
@@ -180,6 +180,7 @@ int scamper_tbit_server_fo_cookie_get(scamper_tbit_t *tbit,
 int scamper_tbit_type_isblind(const scamper_tbit_t *tbit);
 
 /* scamper_tbit_pkt_t functions */
+scamper_tbit_pkt_t *scamper_tbit_pkt_use(scamper_tbit_pkt_t *pkt);
 void scamper_tbit_pkt_free(scamper_tbit_pkt_t *pkt);
 const struct timeval *scamper_tbit_pkt_tv_get(const scamper_tbit_pkt_t *pkt);
 uint8_t scamper_tbit_pkt_dir_get(const scamper_tbit_pkt_t *pkt);

--- a/scamper/tbit/scamper_tbit_cmd.c
+++ b/scamper/tbit/scamper_tbit_cmd.c
@@ -1,7 +1,7 @@
 /*
  * scamper_tbit_cmd.c
  *
- * $Id: scamper_tbit_cmd.c,v 1.5 2024/02/15 06:51:18 mjl Exp $
+ * $Id: scamper_tbit_cmd.c,v 1.8 2024/05/20 07:40:23 mjl Exp $
  *
  * Copyright (C) 2009-2010 Ben Stasiewicz
  * Copyright (C) 2009-2010 Stephen Eichler
@@ -167,7 +167,7 @@ const char *scamper_do_tbit_usage(void)
 {
   return
     "tbit [-t type] [-p app] [-d dport] [-s sport] [-b asn] [-f cookie]\n"
-    "     [-m mss] [-M mtu] [-o offset] [-O option] [-U userid]\n"
+    "     [-m mss] [-M mtu] [-o offset] [-O option] [-U userid] [-w wscale]\n"
     "     [-P ptbsrc] [-q attempts] [-S srcaddr] [-T ttl] [-u url]";
 }
 
@@ -204,7 +204,7 @@ static int tbit_arg_param_validate(int optid, char *param, long long *out,
 	tmp = SCAMPER_TBIT_TYPE_BLIND_FIN;
       else
 	{
-	  snprintf(errbuf, errlen, "unknown tbit type %s", param);
+	  snprintf(errbuf, errlen, "unknown tbit type");
 	  goto err;
 	}
       break;
@@ -216,7 +216,7 @@ static int tbit_arg_param_validate(int optid, char *param, long long *out,
 	tmp = SCAMPER_TBIT_APP_BGP;
       else
 	{
-	  snprintf(errbuf, errlen, "unknown tbit application %s", param);
+	  snprintf(errbuf, errlen, "unknown tbit application");
 	  goto err;
 	}
       break;
@@ -278,7 +278,7 @@ static int tbit_arg_param_validate(int optid, char *param, long long *out,
 	tmp = TBIT_OPT_OPTION_FO_EXP;
       else
 	{
-	  snprintf(errbuf, errlen, "-O %s unknown", param);
+	  snprintf(errbuf, errlen, "unknown option");
 	  goto err;
 	}
       break;
@@ -648,9 +648,8 @@ void *scamper_do_tbit_alloc(char *str, char *errbuf, size_t errlen)
 	 tbit_arg_param_validate(opt->id, opt->str, &tmp,
 				 buf, sizeof(buf)) != 0)
 	{
-	  snprintf(errbuf, errlen, "-%c %s failed: %s",
-		   scamper_options_id2c(opts, opts_cnt, opt->id),
-		   opt->str, buf);
+	  snprintf(errbuf, errlen, "-%c failed: %s",
+		   scamper_options_id2c(opts, opts_cnt, opt->id), buf);
 	  goto err;
 	}
 
@@ -745,7 +744,7 @@ void *scamper_do_tbit_alloc(char *str, char *errbuf, size_t errlen)
       snprintf(errbuf, errlen, "invalid destination address");
       goto err;
     }
-  
+
   tbit->type            = type;
   tbit->userid          = userid;
   tbit->client_wscale   = wscale;

--- a/scamper/tbit/scamper_tbit_do.c
+++ b/scamper/tbit/scamper_tbit_do.c
@@ -1,7 +1,7 @@
 /*
  * scamper_do_tbit.c
  *
- * $Id: scamper_tbit_do.c,v 1.204 2024/02/27 03:34:02 mjl Exp $
+ * $Id: scamper_tbit_do.c,v 1.206 2024/07/02 02:00:31 mjl Exp $
  *
  * Copyright (C) 2009-2010 Ben Stasiewicz
  * Copyright (C) 2009-2010 Stephen Eichler
@@ -776,7 +776,6 @@ static int tbit_reassemble(scamper_task_t *task, scamper_dl_rec_t **out,
     }
 
   timeval_cpy(&newp->dl_tv, &dl->dl_tv);
-  newp->dl_type       = SCAMPER_DL_TYPE_RAW;
   newp->dl_net_type   = SCAMPER_DL_REC_NET_TYPE_IP;
   newp->dl_ifindex    = dl->dl_ifindex;
   newp->dl_af         = dl->dl_af;
@@ -3771,8 +3770,7 @@ static void do_tbit_probe(scamper_task_t *task)
 
   /* Common to all probes */
   probe.pr_dl     = scamper_fd_dl_get(state->dl);
-  probe.pr_dl_buf = state->dlhdr->buf;
-  probe.pr_dl_len = state->dlhdr->len;
+  probe.pr_dlhdr  = state->dlhdr;
   probe.pr_ip_src = tbit->src;
   probe.pr_ip_dst = tbit->dst;
   probe.pr_ip_ttl = tbit->client_ipttl;

--- a/scamper/tbit/scamper_tbit_json.c
+++ b/scamper/tbit/scamper_tbit_json.c
@@ -3,11 +3,11 @@
  *
  * Copyright (c) 2014      Matthew Luckie
  * Copyright (C) 2015      The Regents of the University of California
- * Copyright (C) 2022-2023 Matthew Luckie
+ * Copyright (C) 2022-2024 Matthew Luckie
  *
  * Author: Matthew Luckie
  *
- * $Id: scamper_tbit_json.c,v 1.31 2023/07/29 05:22:23 mjl Exp $
+ * $Id: scamper_tbit_json.c,v 1.33 2024/04/13 01:25:58 mjl Exp $
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -94,7 +94,6 @@ static char *tbit_header_tostr(const scamper_tbit_t *tbit,
   scamper_tbit_app_http_t *http;
   scamper_tbit_app_bgp_t *bgp;
   uint32_t u32;
-  uint8_t u8;
 
   string_concat(buf, sizeof(buf), &off,
 		"{\"type\":\"tbit\", \"tbit_type\":\"%s\", \"userid\":%u",
@@ -127,8 +126,8 @@ static char *tbit_header_tostr(const scamper_tbit_t *tbit,
   if(tbit->client_fo_cookielen > 0)
     {
       string_concat(buf, sizeof(buf), &off, ", \"fo_cookie\":\"");
-      for(u8=0; u8<tbit->client_fo_cookielen; u8++)
-	string_concat(buf,sizeof(buf),&off, "%02x", tbit->client_fo_cookie[u8]);
+      string_byte2hex(buf, sizeof(buf), &off,
+		      tbit->client_fo_cookie, tbit->client_fo_cookielen);
       string_concat(buf, sizeof(buf), &off, "\"");
     }
 
@@ -394,9 +393,7 @@ static char *tbit_pkt_tostr(const scamper_tbit_t *tbit,
 	      if(pp[1] > 2)
 		{
 		  string_concat(buf, sizeof(buf), &off, ", \"cookie\":\"");
-		  for(u16=0; u16<pp[1]-2; u16++)
-		    string_concat(buf, sizeof(buf), &off, "%02x",
-				  pp[2+u16]);
+		  string_byte2hex(buf, sizeof(buf), &off, pp+2, pp[1]-2);
 		  string_concat(buf, sizeof(buf), &off, "\"}");
 		}
 	      tcpoptc++;
@@ -408,9 +405,7 @@ static char *tbit_pkt_tostr(const scamper_tbit_t *tbit,
 	      if(pp[1] > 4)
 		{
 		  string_concat(buf, sizeof(buf), &off, ", \"cookie\":\"");
-		  for(u16=0; u16<pp[1]-4; u16++)
-		    string_concat(buf, sizeof(buf), &off, "%02x",
-				  pp[4+u16]);
+		  string_byte2hex(buf, sizeof(buf), &off, pp+4, pp[1]-4);
 		  string_concat(buf, sizeof(buf), &off, "\"}");
 		}
 	      tcpoptc++;
@@ -454,7 +449,7 @@ int scamper_file_json_tbit_write(const scamper_file_t *sf,
   int rc = -1;
   uint32_t i;
 
-  memset(&state, 0, sizeof(state)); 
+  memset(&state, 0, sizeof(state));
 
   /* put together packet strings, done first to get state for header string */
   len += 11; /* , "pkts":[] */

--- a/scamper/tbit/scamper_tbit_warts.c
+++ b/scamper/tbit/scamper_tbit_warts.c
@@ -7,7 +7,7 @@
  * Copyright (C) 2016-2023 Matthew Luckie
  * Authors: Matthew Luckie, Ben Stasiewicz
  *
- * $Id: scamper_tbit_warts.c,v 1.39 2023/10/02 07:54:10 mjl Exp $
+ * $Id: scamper_tbit_warts.c,v 1.40 2024/03/04 19:36:41 mjl Exp $
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -888,7 +888,7 @@ static int warts_tbit_params_read(scamper_tbit_t *tbit,
 
   if(flag_isset(&buf[o], WARTS_TBIT_TTL) == 0)
     tbit->client_ipttl = 255;
-  
+
   return 0;
 }
 
@@ -1000,7 +1000,7 @@ int scamper_file_warts_tbit_read(scamper_file_t *sf, const warts_hdr_t *hdr,
     case SCAMPER_TBIT_TYPE_BLIND_FIN:
       if((tbit->data = scamper_tbit_blind_alloc()) == NULL)
 	goto err;
-      break;      
+      break;
     }
 
   /* Determine how many tbit_pkts to read */
@@ -1050,7 +1050,7 @@ int scamper_file_warts_tbit_read(scamper_file_t *sf, const warts_hdr_t *hdr,
 	      if(warts_tbit_icw_read(tbit, buf, &i, hdr->len) != 0)
 		goto err;
 	      break;
-	      
+
 	    case SCAMPER_TBIT_TYPE_BLIND_RST:
 	    case SCAMPER_TBIT_TYPE_BLIND_SYN:
 	    case SCAMPER_TBIT_TYPE_BLIND_DATA:
@@ -1147,7 +1147,7 @@ int scamper_file_warts_tbit_write(const scamper_file_t *sf,
 	  warts_tbit_icw_params(tbit, &icw);
 	  len += (2 + 4 + icw.len);
 	  break;
-	  
+
 	case SCAMPER_TBIT_TYPE_BLIND_RST:
 	case SCAMPER_TBIT_TYPE_BLIND_SYN:
 	case SCAMPER_TBIT_TYPE_BLIND_DATA:
@@ -1220,7 +1220,7 @@ int scamper_file_warts_tbit_write(const scamper_file_t *sf,
 	  insert_uint32(buf, &off, len, &icw.len, NULL);
 	  warts_tbit_icw_write(tbit, buf, &off, len, &icw);
 	  break;
-	  
+
 	case SCAMPER_TBIT_TYPE_BLIND_RST:
 	case SCAMPER_TBIT_TYPE_BLIND_SYN:
 	case SCAMPER_TBIT_TYPE_BLIND_DATA:

--- a/scamper/trace/scamper_trace.c
+++ b/scamper/trace/scamper_trace.c
@@ -1,7 +1,7 @@
 /*
  * scamper_trace.c
  *
- * $Id: scamper_trace.c,v 1.116 2023/10/01 07:53:17 mjl Exp $
+ * $Id: scamper_trace.c,v 1.118 2024/04/22 08:56:38 mjl Exp $
  *
  * Copyright (C) 2003-2006 Matthew Luckie
  * Copyright (C) 2003-2011 The University of Waikato
@@ -176,7 +176,6 @@ scamper_addr_t *scamper_trace_dtree_gss_find(const scamper_trace_dtree_t *dtree,
 {
   if(dtree == NULL)
     return NULL;
-  assert(dtree->gssc >= 0);
   return array_find((void **)dtree->gss, (size_t)dtree->gssc, iface,
 		    (array_cmp_t)scamper_addr_cmp);
 }
@@ -185,7 +184,6 @@ void scamper_trace_dtree_gss_sort(const scamper_trace_dtree_t *dtree)
 {
   if(dtree == NULL)
     return;
-  assert(dtree->gssc >= 0);
   array_qsort((void **)dtree->gss, (size_t)dtree->gssc,
 	      (array_cmp_t)scamper_addr_cmp);
   return;
@@ -203,7 +201,7 @@ int scamper_trace_hops_alloc(scamper_trace_t *trace, uint16_t hops)
 
   if(h == NULL)
     return -1;
-  
+
   trace->hops = h;
   return 0;
 }

--- a/scamper/trace/scamper_trace.h
+++ b/scamper/trace/scamper_trace.h
@@ -1,7 +1,7 @@
 /*
  * scamper_trace.h
  *
- * $Id: scamper_trace.h,v 1.160 2024/02/27 02:57:58 mjl Exp $
+ * $Id: scamper_trace.h,v 1.161 2024/03/04 06:59:23 mjl Exp $
  *
  * Copyright (C) 2003-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -60,6 +60,7 @@ char *scamper_trace_stop_tostr(const scamper_trace_t *trace,
 scamper_trace_hop_t *scamper_trace_hop_get(const scamper_trace_t *trace,
 					   uint8_t i);
 uint16_t scamper_trace_hop_count_get(const scamper_trace_t *trace);
+uint8_t scamper_trace_stop_hop_get(const scamper_trace_t *trace);
 
 uint8_t scamper_trace_type_get(const scamper_trace_t *trace);
 char *scamper_trace_type_tostr(const scamper_trace_t *trace,

--- a/scamper/trace/scamper_trace_cmd.c
+++ b/scamper/trace/scamper_trace_cmd.c
@@ -1,7 +1,7 @@
 /*
  * scamper_trace_cmd.c
  *
- * $Id: scamper_trace_cmd.c,v 1.22 2024/03/04 23:40:02 mjl Exp $
+ * $Id: scamper_trace_cmd.c,v 1.24 2024/05/02 02:33:38 mjl Exp $
  *
  * Copyright (C) 2003-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -96,7 +96,7 @@ static const scamper_option_in_t opts[] = {
   {'r', NULL, TRACE_OPT_RTRADDR,     SCAMPER_OPTION_TYPE_STR},
   {'s', NULL, TRACE_OPT_SPORT,       SCAMPER_OPTION_TYPE_NUM},
   {'S', NULL, TRACE_OPT_SRCADDR,     SCAMPER_OPTION_TYPE_STR},
-  {'t', NULL, TRACE_OPT_TOS,         SCAMPER_OPTION_TYPE_NUM},
+  {'t', NULL, TRACE_OPT_TOS,         SCAMPER_OPTION_TYPE_STR},
   {'T', NULL, TRACE_OPT_TTLDST,      SCAMPER_OPTION_TYPE_NULL},
   {'U', NULL, TRACE_OPT_USERID,      SCAMPER_OPTION_TYPE_NUM},
   {'w', NULL, TRACE_OPT_WAITTIMEOUT, SCAMPER_OPTION_TYPE_STR},
@@ -211,7 +211,7 @@ static int trace_arg_param_validate(int optid, char *param, long long *out,
 	tmp = SCAMPER_TRACE_FLAG_RAW;
       else
 	{
-	  snprintf(errbuf, errlen, "-O %s unknown", param);
+	  snprintf(errbuf, errlen, "unknown option");
 	  goto err;
 	}
       break;
@@ -421,9 +421,8 @@ void *scamper_do_trace_alloc(char *str, char *errbuf, size_t errlen)
 	 trace_arg_param_validate(opt->id, opt->str, &tmp,
 				  buf, sizeof(buf)) != 0)
 	{
-	  snprintf(errbuf, errlen, "-%c %s failed: %s",
-		   scamper_options_id2c(opts, opts_cnt, opt->id),
-		   opt->str, buf);
+	  snprintf(errbuf, errlen, "-%c failed: %s",
+		   scamper_options_id2c(opts, opts_cnt, opt->id), buf);
 	  goto err;
 	}
 
@@ -772,7 +771,7 @@ void *scamper_do_trace_alloc(char *str, char *errbuf, size_t errlen)
 	    {
 	      if((sa = scamper_addrcache_resolve(addrcache,af,addr)) == NULL)
 		{
-		  snprintf(errbuf, errlen, "cannot resolve gss %s", addr);
+		  snprintf(errbuf, errlen, "cannot resolve gss");
 		  goto err;
 		}
 	      if(splaytree_find(gss_tree, sa) != NULL ||

--- a/scamper/trace/scamper_trace_do.c
+++ b/scamper/trace/scamper_trace_do.c
@@ -3274,6 +3274,8 @@ static void do_trace_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
     NULL,            /* MODE_DTREE_FIRST */
     NULL,            /* MODE_DTREE_FWD */
     NULL,            /* MODE_DTREE_BACK */
+    dlout_trace,     /* MODE_PARALLEL */
+    dlout_trace,     /* MODE_PARALLEL_FINISH */
   };
 
   static void (* const dlin_func[])(scamper_trace_t *, scamper_dl_rec_t *,
@@ -3290,6 +3292,8 @@ static void do_trace_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
     NULL,            /* MODE_DTREE_FIRST */
     NULL,            /* MODE_DTREE_FWD */
     NULL,            /* MODE_DTREE_BACK */
+    NULL,            /* MODE_PARALLEL */
+    NULL,            /* MODE_PARALLEL_FINISH */
   };
 
   static int (* const handletp_func[])(scamper_task_t *,
@@ -3306,6 +3310,8 @@ static void do_trace_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
     NULL,                /* MODE_DTREE_FIRST */
     NULL,                /* MODE_DTREE_FWD */
     NULL,                /* MODE_DTREE_BACK */
+    NULL,                /* MODE_PARALLEL */
+    NULL,                /* MODE_PARALLEL_FINISH */
   };
   static const int DIR_INBOUND  = 0;
   static const int DIR_OUTBOUND = 1;

--- a/scamper/trace/scamper_trace_do.c
+++ b/scamper/trace/scamper_trace_do.c
@@ -1,7 +1,7 @@
 /*
  * scamper_do_trace.c
  *
- * $Id: scamper_trace_do.c,v 1.369 2024/03/04 23:40:02 mjl Exp $
+ * $Id: scamper_trace_do.c,v 1.374 2024/07/02 01:11:17 mjl Exp $
  *
  * Copyright (C) 2003-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -1459,6 +1459,7 @@ static scamper_trace_hop_t *trace_icmp_hop(const scamper_task_t *task,
   hop->hop_reply_size = ir->ir_ip_size;
   hop->hop_icmp_type  = ir->ir_icmp_type;
   hop->hop_icmp_code  = ir->ir_icmp_code;
+  hop->hop_reply_tos  = ir->ir_ip_tos;
 
   /*
    * we cannot depend on the TTL field of the IP packet being made available,
@@ -1493,22 +1494,13 @@ static scamper_trace_hop_t *trace_icmp_hop(const scamper_task_t *task,
     hop->hop_icmp_nhmtu = ir->ir_icmp_nhmtu;
 
   if(ir->ir_af == AF_INET)
-    {
-      hop->hop_reply_ipid = ir->ir_ip_id;
-      hop->hop_reply_tos  = ir->ir_ip_tos;
-    }
+    hop->hop_reply_ipid = ir->ir_ip_id;
 
   if(SCAMPER_ICMP_RESP_INNER_IS_SET(ir))
     {
       hop->hop_icmp_q_ttl = ir->ir_inner_ip_ttl;
       hop->hop_icmp_q_ipl = ir->ir_inner_ip_size;
-
-      /*
-       * IPv4: record ToS byte
-       * IPv6: might pay to record traffic class byte here.
-       */
-      if(ir->ir_af == AF_INET)
-	hop->hop_icmp_q_tos = ir->ir_inner_ip_tos;
+      hop->hop_icmp_q_tos = ir->ir_inner_ip_tos;
     }
 
   /* if ICMP extensions are included, then parse and include them. */
@@ -1541,16 +1533,14 @@ static scamper_trace_hop_t *trace_dl_hop(scamper_task_t *task,
   /* fill out the basic bits of the hop structure */
   hop->hop_reply_size = dl->dl_ip_size;
   hop->hop_reply_ttl = dl->dl_ip_ttl;
+  hop->hop_reply_tos = dl->dl_ip_tos;
   hop->hop_flags |= (SCAMPER_TRACE_HOP_FLAG_REPLY_TTL |
 		     SCAMPER_TRACE_HOP_FLAG_TS_DL_RX);
   timeval_cpy(&hop->hop_tx, &pr->tx_tv);
   timeval_diff_tv(&hop->hop_rtt, &pr->tx_tv, &dl->dl_tv);
 
   if(dl->dl_af == AF_INET)
-    {
-      hop->hop_reply_ipid = dl->dl_ip_id;
-      hop->hop_reply_tos  = dl->dl_ip_tos;
-    }
+    hop->hop_reply_ipid = dl->dl_ip_id;
 
   if(dl->dl_ip_proto == IPPROTO_TCP)
     {
@@ -3317,6 +3307,8 @@ static void do_trace_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
     NULL,                /* MODE_DTREE_FWD */
     NULL,                /* MODE_DTREE_BACK */
   };
+  static const int DIR_INBOUND  = 0;
+  static const int DIR_OUTBOUND = 1;
 
   scamper_trace_t *trace = trace_getdata(task);
   trace_state_t   *state = trace_getstate(task);
@@ -3361,8 +3353,7 @@ static void do_trace_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
 	     scamper_addr_raw_cmp(trace->dst, dl->dl_ip_dst) == 0 &&
 	     scamper_addr_raw_cmp(trace->src, dl->dl_ip_src) == 0)
 	    {
-	      /* this is an outbound packet */
-	      direction = 1;
+	      direction = DIR_OUTBOUND;
 	      if(trace->type == SCAMPER_TRACE_TYPE_UDP)
 		probe_id = dl->dl_udp_dport - trace->dport;
 	      else if(SCAMPER_TRACE_FLAG_IS_CONSTPAYLOAD(trace) == 0)
@@ -3378,8 +3369,7 @@ static void do_trace_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
 		  scamper_addr_raw_cmp(trace->dst, dl->dl_ip_src) == 0 &&
 		  scamper_addr_raw_cmp(trace->src, dl->dl_ip_dst) == 0)
 	    {
-	      /* this is an inbound packet */
-	      direction = 0;
+	      direction = DIR_INBOUND;
 	      if(trace->type == SCAMPER_TRACE_TYPE_UDP)
 		probe_id = dl->dl_udp_sport - trace->dport;
 	      else
@@ -3400,8 +3390,7 @@ static void do_trace_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
 	  if(dl->dl_icmp_udp_sport != trace->sport)
 	    return;
 
-	  /* this is an inbound packet */
-	  direction = 0;
+	  direction = DIR_INBOUND;
 
 	  if(trace->type == SCAMPER_TRACE_TYPE_UDP)
 	    {
@@ -3447,30 +3436,27 @@ static void do_trace_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
 
       if(SCAMPER_DL_IS_ICMP_ECHO_REQUEST(dl))
 	{
-	  /* this is an outbound packet */
 	  if(dl->dl_icmp_id != trace->sport)
 	    return;
 	  probe_id = dl->dl_icmp_seq;
-	  direction = 1;
+	  direction = DIR_OUTBOUND;
 	}
       else if(SCAMPER_DL_IS_ICMP_ECHO_REPLY(dl))
 	{
-	  /* this is an inbound packet */
 	  if(dl->dl_icmp_id != trace->sport)
 	    return;
 	  probe_id = dl->dl_icmp_seq;
-	  direction = 0;
+	  direction = DIR_INBOUND;
 	}
       else if((SCAMPER_DL_IS_ICMP_TTL_EXP(dl) ||
 	       SCAMPER_DL_IS_ICMP_UNREACH(dl) ||
 	       SCAMPER_DL_IS_ICMP_PACKET_TOO_BIG(dl)) &&
 	      SCAMPER_DL_IS_ICMP_Q_ICMP_ECHO_REQ(dl))
 	{
-	  /* this is an inbound packet */
 	  if(dl->dl_icmp_icmp_id != trace->sport)
 	    return;
 	  probe_id = dl->dl_icmp_icmp_seq;
-	  direction = 0;
+	  direction = DIR_INBOUND;
 	}
       else return;
     }
@@ -3492,8 +3478,7 @@ static void do_trace_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
 	      (trace->type == SCAMPER_TRACE_TYPE_TCP_ACK &&
 	       dl->dl_tcp_flags == TH_ACK)))
 	    {
-	      /* this is an outbound packet */
-	      direction = 1;
+	      direction = DIR_OUTBOUND;
 	      if(dl->dl_af == AF_INET)
 		probe_id = dl->dl_ip_id - 1;
 	      else
@@ -3509,7 +3494,7 @@ static void do_trace_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
 	       * there is no easy way to determine which probe the reply is
 	       * for, so assume it was for the last one
 	       */
-	      direction = 0;
+	      direction = DIR_INBOUND;
 	      probe_id = state->id_next - 1;
 	    }
 	  else return;
@@ -3543,7 +3528,7 @@ static void do_trace_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
 	    }
 
 	  /* this is an inbound packet */
-	  direction = 0;
+	  direction = DIR_INBOUND;
 	}
       else return;
     }
@@ -3558,7 +3543,7 @@ static void do_trace_handle_dl(scamper_task_t *task, scamper_dl_rec_t *dl)
   assert(probe->mode <= MODE_MAX);
 
   /* if this is an inbound packet with a timestamp attached */
-  if(direction == 0)
+  if(direction == DIR_INBOUND)
     {
       /* inbound TCP packets result in a hop record being created */
       if(dl->dl_ip_proto == IPPROTO_TCP || dl->dl_ip_proto == IPPROTO_UDP)
@@ -4234,8 +4219,7 @@ static void do_trace_probe(scamper_task_t *task)
       (SCAMPER_TRACE_TYPE_IS_TCP(trace) && state->raw == NULL)))
     {
       probe.pr_dl     = scamper_fd_dl_get(state->dl);
-      probe.pr_dl_buf = state->dlhdr->buf;
-      probe.pr_dl_len = state->dlhdr->len;
+      probe.pr_dlhdr  = state->dlhdr;
     }
 
   if(trace->payload_len == 0 || MODE_IS_PMTUD(state->mode))

--- a/scamper/trace/scamper_trace_json.c
+++ b/scamper/trace/scamper_trace_json.c
@@ -10,7 +10,7 @@
  *
  * Authors: Brian Hammond, Matthew Luckie
  *
- * $Id: scamper_trace_json.c,v 1.31 2024/03/04 19:36:41 mjl Exp $
+ * $Id: scamper_trace_json.c,v 1.32 2024/04/13 22:31:04 mjl Exp $
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -101,11 +101,11 @@ static char *hop_tostr(const scamper_trace_t *trace, scamper_trace_hop_t *hop)
 	 (trace->flags & SCAMPER_TRACE_FLAG_RXERR) == 0)
 	{
 	  string_concat(buf, sizeof(buf), &off,
-			", \"icmp_q_ttl\":%u, \"icmp_q_ipl\":%u",
-			hop->hop_icmp_q_ttl, hop->hop_icmp_q_ipl);
-	  if(SCAMPER_ADDR_TYPE_IS_IPV4(hop->hop_addr))
-	    string_concat(buf, sizeof(buf), &off, ", \"icmp_q_tos\":%u",
-			  hop->hop_icmp_q_tos);
+			", \"icmp_q_ttl\":%u"
+			", \"icmp_q_ipl\":%u"
+			", \"icmp_q_tos\":%u",
+			hop->hop_icmp_q_ttl, hop->hop_icmp_q_ipl,
+			hop->hop_icmp_q_tos);
 	}
       if(SCAMPER_TRACE_HOP_IS_ICMP_PTB(hop))
 	string_concat(buf, sizeof(buf), &off, ", \"icmp_nhmtu:\":%u",

--- a/scamper/trace/scamper_trace_lib.c
+++ b/scamper/trace/scamper_trace_lib.c
@@ -1,7 +1,7 @@
 /*
  * scamper_trace_lib.c
  *
- * $Id: scamper_trace_lib.c,v 1.7 2023/12/19 05:41:54 mjl Exp $
+ * $Id: scamper_trace_lib.c,v 1.9 2024/03/04 19:36:41 mjl Exp $
  *
  * Copyright (C) 2023 Matthew Luckie
  *
@@ -63,7 +63,7 @@ uint8_t scamper_trace_pmtud_notec_get(const scamper_trace_pmtud_t *pmtud)
 {
   return pmtud->notec;
 }
-  
+
 scamper_trace_hop_t *scamper_trace_pmtud_hops_get(const scamper_trace_pmtud_t *pmtud)
 {
   return pmtud->hops;
@@ -352,6 +352,11 @@ uint8_t scamper_trace_stop_data_get(const scamper_trace_t *trace)
 uint16_t scamper_trace_hop_count_get(const scamper_trace_t *trace)
 {
   return trace->hop_count;
+}
+
+uint8_t scamper_trace_stop_hop_get(const scamper_trace_t *trace)
+{
+  return trace->stop_hop;
 }
 
 scamper_trace_hop_t *scamper_trace_hop_get(const scamper_trace_t *trace,

--- a/scamper/tracelb/scamper_tracelb.c
+++ b/scamper/tracelb/scamper_tracelb.c
@@ -1,7 +1,7 @@
 /*
  * scamper_tracelb.c
  *
- * $Id: scamper_tracelb.c,v 1.79 2023/07/31 07:47:48 mjl Exp $
+ * $Id: scamper_tracelb.c,v 1.80 2024/03/04 19:36:41 mjl Exp $
  *
  * Copyright (C) 2008-2010 The University of Waikato
  * Copyright (C) 2012      The Regents of the University of California
@@ -330,7 +330,7 @@ scamper_tracelb_probeset_t *scamper_tracelb_probeset_alloc(void)
 {
   scamper_tracelb_probeset_t *set;
   if((set = malloc_zero(sizeof(scamper_tracelb_probeset_t))) == NULL)
-    return NULL;  
+    return NULL;
 #ifdef BUILDING_LIBSCAMPERFILE
   set->refcnt = 1;
 #endif

--- a/scamper/tracelb/scamper_tracelb_cmd.c
+++ b/scamper/tracelb/scamper_tracelb_cmd.c
@@ -1,7 +1,7 @@
 /*
  * scamper_tracelb_cmd.c
  *
- * $Id: scamper_tracelb_cmd.c,v 1.7 2024/02/15 01:55:34 mjl Exp $
+ * $Id: scamper_tracelb_cmd.c,v 1.8 2024/05/02 02:33:38 mjl Exp $
  *
  * Copyright (C) 2008-2011 The University of Waikato
  * Copyright (C) 2012      The Regents of the University of California
@@ -160,7 +160,7 @@ static int tracelb_arg_param_validate(int optid, char *param, long long *out,
 	}
       else
 	{
-	  snprintf(errbuf, errlen, "-O %s unknown", param);
+	  snprintf(errbuf, errlen, "unknown option");
 	  goto err;
 	}
       break;
@@ -292,9 +292,8 @@ void *scamper_do_tracelb_alloc(char *str, char *errbuf, size_t errlen)
 	 tracelb_arg_param_validate(opt->id, opt->str, &tmp,
 				    buf, sizeof(buf)) != 0)
 	{
-	  snprintf(errbuf, errlen, "-%c %s failed: %s",
-		   scamper_options_id2c(opts, opts_cnt, opt->id),
-		   opt->str, buf);
+	  snprintf(errbuf, errlen, "-%c failed: %s",
+		   scamper_options_id2c(opts, opts_cnt, opt->id), buf);
 	  goto err;
 	}
 

--- a/scamper/tracelb/scamper_tracelb_do.c
+++ b/scamper/tracelb/scamper_tracelb_do.c
@@ -1,7 +1,7 @@
 /*
  * scamper_tracelb_do.c
  *
- * $Id: scamper_tracelb_do.c,v 1.308 2024/02/28 04:25:07 mjl Exp $
+ * $Id: scamper_tracelb_do.c,v 1.310 2024/07/02 01:11:17 mjl Exp $
  *
  * Copyright (C) 2008-2011 The University of Waikato
  * Copyright (C) 2012      The Regents of the University of California
@@ -571,7 +571,7 @@ static tracelb_link_t *tracelb_isloop_addr(const tracelb_path_t *path,
 
 	  /*
 	   * if the link includes a clump, then check the replies in
-	   * the clump 
+	   * the clump
 	   */
 	  if(link->hopc > 0)
 	    {
@@ -4333,8 +4333,7 @@ static void do_tracelb_probe(scamper_task_t *task)
   if(state->dl != NULL)
     {
       probe.pr_dl        = scamper_fd_dl_get(state->dl);
-      probe.pr_dl_buf    = state->dlhdr->buf;
-      probe.pr_dl_len    = state->dlhdr->len;
+      probe.pr_dlhdr     = state->dlhdr;
     }
 
   if(scamper_probe(&probe) == -1)
@@ -4415,7 +4414,7 @@ scamper_task_t *scamper_do_tracelb_alloctask(void *data,
     case SCAMPER_TRACELB_TYPE_UDP_SPORT:
       SCAMPER_TASK_SIG_UDP_SPORT(sig, 0, 65535, trace->dport);
       break;
-      
+
     case SCAMPER_TRACELB_TYPE_TCP_SPORT:
     case SCAMPER_TRACELB_TYPE_TCP_ACK_SPORT:
       SCAMPER_TASK_SIG_TCP_SPORT(sig, 0, 65535, trace->dport);
@@ -4425,7 +4424,7 @@ scamper_task_t *scamper_do_tracelb_alloctask(void *data,
       snprintf(errbuf, errlen, "%s: unhandled type %d", __func__, trace->type);
       goto err;
     }
-  
+
   if(scamper_task_sig_add(task, sig) != 0)
     {
       snprintf(errbuf, errlen, "%s: could not add signature to task", __func__);

--- a/scamper/udpprobe/scamper_udpprobe.c
+++ b/scamper/udpprobe/scamper_udpprobe.c
@@ -1,7 +1,7 @@
 /*
  * scamper_udpprobe.c
  *
- * $Id: scamper_udpprobe.c,v 1.1 2023/11/22 04:10:09 mjl Exp $
+ * $Id: scamper_udpprobe.c,v 1.2 2024/04/04 06:55:33 mjl Exp $
  *
  * Copyright (C) 2023 The Regents of the University of California
  *

--- a/scamper/udpprobe/scamper_udpprobe.h
+++ b/scamper/udpprobe/scamper_udpprobe.h
@@ -1,7 +1,7 @@
 /*
  * scamper_udpprobe.h
  *
- * $Id: scamper_udpprobe.h,v 1.3 2023/11/22 20:43:17 mjl Exp $
+ * $Id: scamper_udpprobe.h,v 1.5 2024/04/04 22:57:01 mjl Exp $
  *
  * Copyright (C) 2023 The Regents of the University of California
  *
@@ -48,11 +48,12 @@ uint8_t scamper_udpprobe_stop_count_get(const scamper_udpprobe_t *up);
 scamper_udpprobe_probe_t *scamper_udpprobe_probe_get(const scamper_udpprobe_t *up, uint8_t i);
 
 /* scamper_udpprobe_probe_t functions */
+void scamper_udpprobe_probe_free(scamper_udpprobe_probe_t *pr);
+scamper_udpprobe_probe_t *scamper_udpprobe_probe_use(scamper_udpprobe_probe_t *probe);
 const struct timeval *scamper_udpprobe_probe_tx_get(const scamper_udpprobe_probe_t *probe);
 uint16_t scamper_udpprobe_probe_sport_get(const scamper_udpprobe_probe_t *probe);
 scamper_udpprobe_reply_t *scamper_udpprobe_probe_reply_get(const scamper_udpprobe_probe_t *probe, uint8_t i);
 uint8_t scamper_udpprobe_probe_replyc_get(const scamper_udpprobe_probe_t *probe);
-void scamper_udpprobe_probe_free(scamper_udpprobe_probe_t *pr);
 
 /* scamper_udpprobe_reply_t functions */
 void scamper_udpprobe_reply_free(scamper_udpprobe_reply_t *ur);

--- a/scamper/udpprobe/scamper_udpprobe_cmd.c
+++ b/scamper/udpprobe/scamper_udpprobe_cmd.c
@@ -1,7 +1,7 @@
 /*
  * scamper_udpprobe_cmd.c
  *
- * $Id: scamper_udpprobe_cmd.c,v 1.10 2024/02/21 04:58:05 mjl Exp $
+ * $Id: scamper_udpprobe_cmd.c,v 1.12 2024/05/02 02:33:38 mjl Exp $
  *
  * Copyright (C) 2023-2024 The Regents of the University of California
  *
@@ -108,7 +108,7 @@ static int udpprobe_arg_param_validate(int optid, char *param, long long *out,
 	tmp = SCAMPER_UDPPROBE_FLAG_EXITFIRST;
       else
 	{
-	  snprintf(errbuf, errlen, "-O %s unknown", param);
+	  snprintf(errbuf, errlen, "unknown option");
 	  goto err;
 	}
       break;
@@ -227,9 +227,8 @@ void *scamper_do_udpprobe_alloc(char *str, char *errbuf, size_t errlen)
 	 udpprobe_arg_param_validate(opt->id, opt->str, &tmp,
 				     buf, sizeof(buf)) != 0)
 	{
-	  snprintf(errbuf, errlen, "-%c %s failed: %s",
-		   scamper_options_id2c(opts, opts_cnt, opt->id),
-		   opt->str, buf);
+	  snprintf(errbuf, errlen, "-%c failed: %s",
+		   scamper_options_id2c(opts, opts_cnt, opt->id), buf);
 	  goto err;
 	}
 

--- a/scamper/udpprobe/scamper_udpprobe_int.h
+++ b/scamper/udpprobe/scamper_udpprobe_int.h
@@ -1,7 +1,7 @@
 /*
  * scamper_udpprobe_int.h
  *
- * $Id: scamper_udpprobe_int.h,v 1.2 2023/11/22 20:43:17 mjl Exp $
+ * $Id: scamper_udpprobe_int.h,v 1.3 2024/04/04 06:55:33 mjl Exp $
  *
  * Copyright (C) 2023 The Regents of the University of California
  *

--- a/scamper/udpprobe/scamper_udpprobe_json.c
+++ b/scamper/udpprobe/scamper_udpprobe_json.c
@@ -3,7 +3,7 @@
  *
  * Author: Matthew Luckie
  *
- * $Id$
+ * $Id: scamper_udpprobe_json.c,v 1.3 2024/04/13 01:25:58 mjl Exp $
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -42,7 +42,6 @@ static char *reply_tostr(const scamper_udpprobe_probe_t *probe,
   struct timeval rtt;
   char buf[(65536 * 2) + 512];
   size_t off = 0;
-  uint16_t i;
 
   if(reply == NULL)
     {
@@ -58,12 +57,10 @@ static char *reply_tostr(const scamper_udpprobe_probe_t *probe,
 		(long)reply->rx.tv_sec, (int)reply->rx.tv_usec,
 		(long)rtt.tv_sec, (int)rtt.tv_usec,
 		reply->len);
-  for(i=0; i<reply->len; i++)
-    string_concat(buf, sizeof(buf), &off, "%02x", reply->data[i]);
+  string_byte2hex(buf, sizeof(buf), &off, reply->data, reply->len);
   string_concat(buf, sizeof(buf), &off, "\"}");
 
   *len = off;
-
   return strdup(buf);
 }
 
@@ -139,7 +136,6 @@ static char *header_tostr(const scamper_udpprobe_t *up)
   static const char *stop_m[] = {"none", "done", "halted", "error"};
   char buf[4096], tmp[512];
   size_t off = 0;
-  uint16_t i;
 
   string_concat(buf, sizeof(buf), &off,
 		"{\"type\":\"udpprobe\", \"version\":\"0.1\"");
@@ -168,8 +164,7 @@ static char *header_tostr(const scamper_udpprobe_t *up)
   string_concat(buf, sizeof(buf), &off, "\"");
 
   string_concat(buf, sizeof(buf), &off, ", \"data\":\"");
-  for(i=0; i<up->len; i++)
-    string_concat(buf, sizeof(buf), &off, "%02x", up->data[i]);
+  string_byte2hex(buf, sizeof(buf), &off, up->data, up->len);
   string_concat(buf, sizeof(buf), &off, "\", \"len\":%u", up->len);
 
   string_concat(buf, sizeof(buf), &off,

--- a/scamper/udpprobe/scamper_udpprobe_json.h
+++ b/scamper/udpprobe/scamper_udpprobe_json.h
@@ -1,7 +1,7 @@
 /*
  * scamper_udpprobe_json.h
  *
- * $Id$
+ * $Id: scamper_udpprobe_json.h,v 1.1 2024/03/21 22:44:03 mjl Exp $
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/scamper/udpprobe/scamper_udpprobe_lib.c
+++ b/scamper/udpprobe/scamper_udpprobe_lib.c
@@ -1,7 +1,7 @@
 /*
  * scamper_udpprobe_lib.c
  *
- * $Id: scamper_udpprobe_lib.c,v 1.3 2023/11/22 20:43:17 mjl Exp $
+ * $Id: scamper_udpprobe_lib.c,v 1.5 2024/04/04 22:57:01 mjl Exp $
  *
  * Copyright (C) 2023 The Regents of the University of California
  *
@@ -164,3 +164,11 @@ uint8_t scamper_udpprobe_probe_replyc_get(const scamper_udpprobe_probe_t *probe)
 {
   return probe->replyc;
 }
+
+#ifdef BUILDING_LIBSCAMPERFILE
+scamper_udpprobe_probe_t *scamper_udpprobe_probe_use(scamper_udpprobe_probe_t *pr)
+{
+  pr->refcnt++;
+  return pr;
+}
+#endif

--- a/scamper/udpprobe/scamper_udpprobe_warts.c
+++ b/scamper/udpprobe/scamper_udpprobe_warts.c
@@ -5,7 +5,7 @@
  *
  * Author: Matthew Luckie
  *
- * $Id: scamper_udpprobe_warts.c,v 1.3 2023/11/22 21:53:57 mjl Exp $
+ * $Id: scamper_udpprobe_warts.c,v 1.5 2024/04/04 06:55:33 mjl Exp $
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -386,7 +386,7 @@ static int warts_udpprobe_params_write(const scamper_udpprobe_t *up,
     {&up->dport,          (wpw_t)insert_uint16,       NULL},
     {&up->start,          (wpw_t)insert_timeval,      NULL},
     {&up->wait_timeout,   (wpw_t)insert_rtt,          NULL},
-    {&up->flags,          (wpw_t)insert_byte,         NULL},    
+    {&up->flags,          (wpw_t)insert_byte,         NULL},
     {&up->stop,           (wpw_t)insert_byte,         NULL},
     {&up->len,            (wpw_t)insert_uint16,       NULL},
     {up->data,            (wpw_t)insert_bytes_uint16, &up_len},

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,4 +1,4 @@
-# $Id: Makefile.am,v 1.26 2024/02/20 21:05:14 mjl Exp $
+# $Id: Makefile.am,v 1.30 2024/07/02 00:50:12 mjl Exp $
 
 AUTOMAKE_OPTIONS = subdir-objects
 
@@ -27,13 +27,17 @@ noinst_PROGRAMS = \
 	unit_addr \
 	fuzz_osinfo \
 	unit_osinfo \
+	fuzz_dl_parse_arp \
+	unit_dl_parse_arp \
 	fuzz_dl_parse_ip \
 	unit_dl_parse_ip \
 	fuzz_http_lib_chunked \
 	fuzz_http_lib_hdrs \
 	unit_http_lib \
+	fuzz_host_rr_list \
 	unit_host_rr_list \
 	unit_options \
+	unit_string \
 	unit_timeval \
 	unit_fds
 
@@ -46,6 +50,7 @@ libcmdtest_a_SOURCES = \
 	../scamper/scamper_list.c \
 	../scamper/scamper_options.c \
 	../scamper/scamper_icmpext.c \
+	../scamper/scamper_ifname.c \
 	../mjl_splaytree.c \
 	../mjl_list.c \
 	common.c
@@ -192,15 +197,29 @@ fuzz_osinfo_LDADD = libosinfotest.a
 unit_osinfo_SOURCES = unit_osinfo.c
 unit_osinfo_LDADD = libosinfotest.a
 
+fuzz_dl_parse_arp_CFLAGS = -DTEST_DL_PARSE_ARP
+fuzz_dl_parse_arp_SOURCES = fuzz_dl_parse.c \
+	../scamper/scamper_dl.c \
+	../utils.c
+
+unit_dl_parse_arp_CFLAGS = -DTEST_DL_PARSE_ARP
+unit_dl_parse_arp_SOURCES = unit_dl_parse_arp.c \
+	../scamper/scamper_dl.c \
+	../scamper/scamper_addr.c \
+	../utils.c \
+	common.c
+
 fuzz_dl_parse_ip_CFLAGS = -DTEST_DL_PARSE_IP
-fuzz_dl_parse_ip_SOURCES = fuzz_dl_parse_ip.c \
+fuzz_dl_parse_ip_SOURCES = fuzz_dl_parse.c \
 	../scamper/scamper_dl.c \
 	../utils.c
 
 unit_dl_parse_ip_CFLAGS = -DTEST_DL_PARSE_IP
 unit_dl_parse_ip_SOURCES = unit_dl_parse_ip.c \
 	../scamper/scamper_dl.c \
-	../utils.c
+	../scamper/scamper_addr.c \
+	../utils.c \
+	common.c
 
 fuzz_http_lib_chunked_CFLAGS = -I$(top_srcdir)/scamper/http -DFUZZ_CHUNKED
 fuzz_http_lib_chunked_SOURCES = fuzz_http_lib.c \
@@ -220,6 +239,16 @@ unit_http_lib_SOURCES = unit_http_lib.c \
 	../scamper/http/scamper_http_lib.c
 unit_http_lib_LDADD = libcmdtest.a
 
+fuzz_host_rr_list_CFLAGS = -I$(top_srcdir)/scamper/host -DTEST_HOST_RR_LIST
+fuzz_host_rr_list_SOURCES = fuzz_host_rr_list.c \
+	../scamper/host/scamper_host_do.c \
+	../scamper/host/scamper_host.c \
+	../scamper/scamper_addr.c \
+	../scamper/scamper_list.c \
+	../mjl_list.c \
+	../utils.c \
+	common.c
+
 unit_host_rr_list_CFLAGS = -I$(top_srcdir)/scamper/host -DTEST_HOST_RR_LIST
 unit_host_rr_list_SOURCES = unit_host_rr_list.c \
 	../scamper/host/scamper_host_do.c \
@@ -233,6 +262,9 @@ unit_host_rr_list_SOURCES = unit_host_rr_list.c \
 
 unit_options_SOURCES = unit_options.c \
 	../scamper/scamper_options.c \
+	../utils.c
+
+unit_string_SOURCES = unit_string.c \
 	../utils.c
 
 unit_timeval_SOURCES = unit_timeval.c \

--- a/tests/common.c
+++ b/tests/common.c
@@ -1,7 +1,7 @@
 /*
  * common.c: common functions that we might need for linking unit tests
  *
- * $Id: common.c,v 1.5 2024/02/27 08:14:29 mjl Exp $
+ * $Id: common.c,v 1.7 2024/07/02 00:50:12 mjl Exp $
  *
  *        Matthew Luckie
  *        mjl@luckie.org.nz
@@ -77,6 +77,77 @@ int dump_cmd(const char *cmd, const char *filename)
       fprintf(stderr, "%s: could not write %s: %s\n",
 	      __func__, filename, strerror(errno));
       goto done;
+    }
+
+  rc = 0;
+
+ done:
+  if(fd != -1) close(fd);
+  if(buf != NULL) free(buf);
+  return rc;
+}
+
+int hex2buf(const char *str, uint8_t **buf_out, size_t *len_out)
+{
+  size_t i, len, off = 0;
+  uint8_t *buf = NULL;
+  int rc = -1;
+
+  if((len = strlen(str)) == 0)
+    {
+      *buf_out = NULL;
+      *len_out = 0;
+      return 0;
+    }
+
+  if((len % 2) != 0 || (buf = malloc(len / 2)) == NULL)
+    goto done;
+
+  for(i=0; i<len; i+=2)
+    {
+      if(ishex(str[i]) == 0 || ishex(str[i+1]) == 0)
+	goto done;
+      buf[off++] = hex2byte(str[i], str[i+1]);
+    }
+
+  *buf_out = buf; buf = NULL;
+  *len_out = off;
+  rc = 0;
+
+ done:
+  if(buf != NULL) free(buf);
+  return rc;
+}
+
+int dump_hex(const char *str, const char *filename)
+{
+  size_t len, wc;
+  uint8_t *buf = NULL;
+  int rc = -1, fd = -1;
+  int fd_flags = O_WRONLY | O_CREAT | O_TRUNC;
+
+#ifdef _WIN32 /* windows needs O_BINARY */
+  fd_flags |= O_BINARY;
+#endif
+
+  if(hex2buf(str, &buf, &len) != 0)
+    goto done;
+
+  if(len > 0)
+    {
+      if((fd = open(filename, fd_flags, MODE_644)) == -1)
+	{
+	  fprintf(stderr, "%s: could not open %s: %s\n",
+		  __func__, filename, strerror(errno));
+	  goto done;
+	}
+
+      if(write_wrap(fd, buf, &wc, len) != 0 || wc != len)
+	{
+	  fprintf(stderr, "%s: could not write %s: %s\n",
+		  __func__, filename, strerror(errno));
+	  goto done;
+	}
     }
 
   rc = 0;

--- a/tests/common.h
+++ b/tests/common.h
@@ -1,7 +1,7 @@
 /*
  * common.h : functions common to unit tests
  *
- * $Id: common.h,v 1.2 2023/11/27 07:56:14 mjl Exp $
+ * $Id: common.h,v 1.3 2024/04/20 00:15:02 mjl Exp $
  *
  *        Matthew Luckie
  *        mjl@luckie.org.nz
@@ -25,3 +25,5 @@
 
 int dump_cmd(const char *cmd, const char *filename);
 int check_addr(const scamper_addr_t *sa, const char *str);
+int dump_hex(const char *str, const char *filename);
+int hex2buf(const char *str, uint8_t **buf_out, size_t *len_out);

--- a/tests/fuzz-tmux.sh
+++ b/tests/fuzz-tmux.sh
@@ -6,13 +6,21 @@ FUZZDIR=${1?}
 
 mkdir -p ${FUZZDIR}
 
+if [ -r "/proc/sys/kernel/core_pattern" ]; then
+    line=$(head -n 1 /proc/sys/kernel/core_pattern)
+    if [ "$line" != "core" ]; then
+	echo "unexpected core pattern $line"
+	exit 1
+    fi
+fi
+
 prepare()
 {
     ARG_TYPE=$1
 
-    mkdir -p ${FUZZDIR}/cmd_${ARG_TYPE}/input
-    ./unit_cmd_${ARG_TYPE} dump ${FUZZDIR}/cmd_${ARG_TYPE}/input
-    afl-cmin -i ${FUZZDIR}/cmd_${ARG_TYPE}/input -o ${FUZZDIR}/cmd_${ARG_TYPE}/testcases -- ./fuzz_cmd_${ARG_TYPE} @@
+    mkdir -p ${FUZZDIR}/${ARG_TYPE}/input
+    ./unit_${ARG_TYPE} dump ${FUZZDIR}/${ARG_TYPE}/input
+    afl-cmin -i ${FUZZDIR}/${ARG_TYPE}/input -o ${FUZZDIR}/${ARG_TYPE}/testcases -- ./fuzz_${ARG_TYPE} @@
 }
 
 fuzz_tmux()
@@ -21,43 +29,67 @@ fuzz_tmux()
     ARG_WINDOW=$2
 
     tmux set-window-option -t ${ARG_WINDOW} remain-on-exit on
-    tmux send-keys -t ${ARG_WINDOW} "AFL_TMPDIR=${FUZZDIR}/cmd_${ARG_TYPE} AFL_SKIP_CPUFREQ=1 afl-fuzz -i ${FUZZDIR}/cmd_${ARG_TYPE}/testcases -o ${FUZZDIR}/cmd_${ARG_TYPE}/findings -- ./fuzz_cmd_${ARG_TYPE} @@" C-m
+    tmux send-keys -t ${ARG_WINDOW} "AFL_TMPDIR=${FUZZDIR}/${ARG_TYPE} AFL_SKIP_CPUFREQ=1 afl-fuzz -i ${FUZZDIR}/${ARG_TYPE}/testcases -o ${FUZZDIR}/${ARG_TYPE}/findings -- ./fuzz_${ARG_TYPE} @@" C-m
 }
 
-prepare dealias
-prepare host
-prepare http
-prepare ping
-prepare sniff
-prepare sting
-prepare tbit
-prepare trace
-prepare udpprobe
+prepare cmd_dealias
+prepare cmd_host
+prepare cmd_http
+prepare cmd_ping
+prepare cmd_sniff
+prepare cmd_sting
+prepare cmd_tbit
+prepare cmd_trace
+prepare cmd_udpprobe
+prepare dl_parse_arp
+prepare dl_parse_ip
+prepare host_rr_list
 
-tmux new-session -d -s fuzz-cmd
-tmux rename-window -t fuzz-cmd:0 'fuzz-cmd-dealias'
-fuzz_tmux dealias fuzz-cmd:0
+WIN=0
+tmux new-session -d -s fuzz-scamper
+tmux rename-window -t fuzz-scamper:${WIN} 'fuzz-cmd-dealias'
+fuzz_tmux cmd_dealias fuzz-scamper:${WIN}
 
-tmux new-window -t fuzz-cmd:1 -n 'fuzz-cmd-host'
-fuzz_tmux host fuzz-cmd:1
+WIN=`expr ${WIN} + 1`
+tmux new-window -t fuzz-scamper:${WIN} -n 'fuzz-cmd-host'
+fuzz_tmux cmd_host fuzz-scamper:${WIN}
 
-tmux new-window -t fuzz-cmd:2 -n 'fuzz-cmd-http'
-fuzz_tmux http fuzz-cmd:2
+WIN=`expr ${WIN} + 1`
+tmux new-window -t fuzz-scamper:${WIN} -n 'fuzz-cmd-http'
+fuzz_tmux cmd_http fuzz-scamper:${WIN}
 
-tmux new-window -t fuzz-cmd:3 -n 'fuzz-cmd-ping'
-fuzz_tmux ping fuzz-cmd:3
+WIN=`expr ${WIN} + 1`
+tmux new-window -t fuzz-scamper:${WIN} -n 'fuzz-cmd-ping'
+fuzz_tmux cmd_ping fuzz-scamper:${WIN}
 
-tmux new-window -t fuzz-cmd:4 -n 'fuzz-cmd-sniff'
-fuzz_tmux sniff fuzz-cmd:4
+WIN=`expr ${WIN} + 1`
+tmux new-window -t fuzz-scamper:${WIN} -n 'fuzz-cmd-sniff'
+fuzz_tmux cmd_sniff fuzz-scamper:${WIN}
 
-tmux new-window -t fuzz-cmd:5 -n 'fuzz-cmd-sting'
-fuzz_tmux sting fuzz-cmd:5
+WIN=`expr ${WIN} + 1`
+tmux new-window -t fuzz-scamper:${WIN} -n 'fuzz-cmd-sting'
+fuzz_tmux cmd_sting fuzz-scamper:${WIN}
 
-tmux new-window -t fuzz-cmd:6 -n 'fuzz-cmd-tbit'
-fuzz_tmux tbit fuzz-cmd:6
+WIN=`expr ${WIN} + 1`
+tmux new-window -t fuzz-scamper:${WIN} -n 'fuzz-cmd-tbit'
+fuzz_tmux cmd_tbit fuzz-scamper:${WIN}
 
-tmux new-window -t fuzz-cmd:7 -n 'fuzz-cmd-trace'
-fuzz_tmux trace fuzz-cmd:7
+WIN=`expr ${WIN} + 1`
+tmux new-window -t fuzz-scamper:${WIN} -n 'fuzz-cmd-trace'
+fuzz_tmux cmd_trace fuzz-scamper:${WIN}
 
-tmux new-window -t fuzz-cmd:8 -n 'fuzz-cmd-udpprobe'
-fuzz_tmux udpprobe fuzz-cmd:8
+WIN=`expr ${WIN} + 1`
+tmux new-window -t fuzz-scamper:${WIN} -n 'fuzz-cmd-udpprobe'
+fuzz_tmux cmd_udpprobe fuzz-scamper:${WIN}
+
+WIN=`expr ${WIN} + 1`
+tmux new-window -t fuzz-scamper:${WIN} -n 'fuzz-dl-parse-arp'
+fuzz_tmux dl_parse_arp fuzz-scamper:${WIN}
+
+WIN=`expr ${WIN} + 1`
+tmux new-window -t fuzz-scamper:${WIN} -n 'fuzz-dl-parse-ip'
+fuzz_tmux dl_parse_ip fuzz-scamper:${WIN}
+
+WIN=`expr ${WIN} + 1`
+tmux new-window -t fuzz-scamper:${WIN} -n 'fuzz-host-rr-list'
+fuzz_tmux host_rr_list fuzz-scamper:${WIN}

--- a/tests/fuzz_dl_parse.c
+++ b/tests/fuzz_dl_parse.c
@@ -1,12 +1,12 @@
 /*
- * fuzz_dl_parse_ip : fuzz dl_parse_ip function
+ * fuzz_dl_parse : fuzz dl_parse functions
  *
- * $Id: fuzz_dl_parse_ip.c,v 1.3 2023/10/08 04:14:17 mjl Exp $
+ * $Id: fuzz_dl_parse.c,v 1.1 2024/07/02 00:50:12 mjl Exp $
  *
  *        Matthew Luckie
  *        mjl@luckie.org.nz
  *
- * Copyright (C) 2023 Matthew Luckie
+ * Copyright (C) 2023-2024 Matthew Luckie
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -35,7 +35,13 @@
  * function prototype of a normally static function that is not in
  * scamper_dl.h
  */
+#ifdef TEST_DL_PARSE_IP
 int dl_parse_ip(scamper_dl_rec_t *dl, uint8_t *pktbuf, size_t pktlen);
+#endif
+
+#ifdef TEST_DL_PARSE_ARP
+int dl_parse_arp(scamper_dl_rec_t *dl, uint8_t *pktbuf, size_t pktlen);
+#endif
 
 int main(int argc, char *argv[])
 {
@@ -56,7 +62,13 @@ int main(int argc, char *argv[])
   if(read_wrap(fd, buf, &readc, len) != 0 || readc != len)
     goto done;
 
+#ifdef TEST_DL_PARSE_IP
   dl_parse_ip(&dlr, buf, len);
+#endif
+#ifdef TEST_DL_PARSE_ARP
+  dl_parse_arp(&dlr, buf, len);
+#endif
+
   rc = 0;
 
  done:

--- a/tests/fuzz_host_rr_list.c
+++ b/tests/fuzz_host_rr_list.c
@@ -1,0 +1,129 @@
+/*
+ * fuzz_host_rr_list : fuzz RR parsing
+ *
+ * $Id: fuzz_host_rr_list.c,v 1.1 2024/04/20 00:15:02 mjl Exp $
+ *
+ *        Matthew Luckie
+ *        mjl@luckie.org.nz
+ *
+ * Copyright (C) 2024 Matthew Luckie
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "internal.h"
+
+#include "scamper_list.h"
+#include "scamper_addr.h"
+#include "scamper_host.h"
+#include "scamper_host_int.h"
+
+#include "utils.h"
+#include "mjl_list.h"
+
+/* function prototype of two normally static functions */
+slist_t *host_rr_list(const uint8_t *buf, size_t off, size_t len);
+int extract_name(char *name, size_t namelen,
+		 const uint8_t *pbuf, size_t plen, size_t off);
+
+static void check(const uint8_t *pktbuf, size_t len)
+{
+  slist_t *rr_list;
+  char name[256];
+  int i;
+
+  if((i = extract_name(name, sizeof(name), pktbuf, len, 12)) > 0 &&
+     (rr_list = host_rr_list(pktbuf, 12 + 4 + i, len)) != NULL)
+    {
+      slist_free_cb(rr_list, (slist_free_t)scamper_host_rr_free);
+    }
+  return;
+}
+
+static int input(const char *filename, uint8_t **out, size_t *len)
+{
+  uint8_t *buf = NULL;
+  struct stat sb;
+  size_t readc;
+  int fd = -1;
+
+  if((fd = open(filename, O_RDONLY)) == -1 ||
+     fstat(fd, &sb) != 0)
+    goto err;
+  *len = sb.st_size;
+  if((buf = malloc(*len)) == NULL ||
+     read_wrap(fd, buf, &readc, *len) != 0 || readc != *len)
+    goto err;
+
+  close(fd);
+  *out = buf;
+  return 0;
+
+ err:
+  if(buf != NULL) free(buf);
+  if(fd != -1) close(fd);
+  return -1;
+}
+
+int main(int argc, char *argv[])
+{
+  uint8_t *buf = NULL;
+  size_t len;
+
+#ifdef DMALLOC
+  unsigned long start_mem, stop_mem;
+  int assert_mem = 1;
+#endif
+
+  if(argc < 2)
+    {
+      printf("missing input\n");
+      return -1;
+    }
+
+  if(argc > 2)
+    {
+#ifdef DMALLOC
+      if(strcmp(argv[2], "0") == 0)
+	assert_mem = 0;
+#else
+      fprintf(stderr, "not compiled with dmalloc support\n");
+      return -1;
+#endif
+    }
+
+#ifdef DMALLOC
+  dmalloc_get_stats(NULL, NULL, NULL, NULL, &start_mem, NULL, NULL, NULL, NULL);
+#endif
+
+  if(input(argv[1], &buf, &len) != 0)
+    return -1;
+
+  check(buf, len);
+
+  if(buf != NULL)
+    free(buf);
+
+#ifdef DMALLOC
+  dmalloc_get_stats(NULL, NULL, NULL, NULL, &stop_mem, NULL, NULL, NULL, NULL);
+  if(assert_mem != 0)
+    assert(start_mem == stop_mem);
+#endif
+
+  return 0;
+}

--- a/tests/fuzz_http_lib.c
+++ b/tests/fuzz_http_lib.c
@@ -1,7 +1,7 @@
 /*
  * unit_http_lib: fuzz http library
  *
- * $Id: fuzz_http_lib.c,v 1.1 2023/10/26 04:55:21 mjl Exp $
+ * $Id: fuzz_http_lib.c,v 1.2 2024/03/04 19:36:41 mjl Exp $
  *
  *        Matthew Luckie
  *        mjl@luckie.org.nz
@@ -39,7 +39,7 @@ static scamper_http_buf_t *htb_make(uint8_t dir, uint8_t type,
 				    const uint8_t *data, uint16_t len)
 {
   scamper_http_buf_t *htb;
-  
+
   if((htb = scamper_http_buf_alloc()) == NULL ||
      (htb->data = memdup(data, len)) == NULL)
     goto err;

--- a/tests/fuzz_osinfo.c
+++ b/tests/fuzz_osinfo.c
@@ -1,7 +1,7 @@
 /*
  * fuzz_osinfo : simple program to fuzz osinfo
  *
- * $Id: fuzz_osinfo.c,v 1.1 2023/08/07 21:02:30 mjl Exp $
+ * $Id: fuzz_osinfo.c,v 1.2 2024/03/04 19:36:41 mjl Exp $
  *
  *        Matthew Luckie
  *        mjl@luckie.org.nz
@@ -76,5 +76,5 @@ int main(int argc, char *argv[])
       return -1;
     }
 
-  return 0;    
+  return 0;
 }

--- a/tests/unit-all.pl
+++ b/tests/unit-all.pl
@@ -16,12 +16,14 @@ my @tests = (
     "unit_cmd_tbit",
     "unit_cmd_trace",
     "unit_cmd_udpprobe",
+    "unit_dl_parse_arp",
     "unit_dl_parse_ip",
     "unit_fds",
     "unit_host_rr_list",
     "unit_http_lib",
     "unit_options",
     "unit_osinfo",
+    "unit_string",
     "unit_timeval",
     );
 foreach my $test (@tests)

--- a/tests/unit_cmd_dealias.c
+++ b/tests/unit_cmd_dealias.c
@@ -1,7 +1,7 @@
 /*
  * unit_cmd_dealias : unit tests for dealias commands
  *
- * $Id: unit_cmd_dealias.c,v 1.28 2024/02/14 08:09:25 mjl Exp $
+ * $Id: unit_cmd_dealias.c,v 1.29 2024/03/04 19:36:41 mjl Exp $
  *
  *        Matthew Luckie
  *        mjl@luckie.org.nz
@@ -685,9 +685,9 @@ int main(int argc, char *argv[])
      " -p '-P icmp-echo -i 192.0.2.1' 192.0.2.2", isnull},
     {"-m ally -W 1000"
      " -p '-P icmp-echo -i 192.0.2.1' 192.0.2.1 192.0.2.2", isnull},
-    /* valid mercator without a probedef */    
+    /* valid mercator without a probedef */
     {"-m mercator 192.0.2.1", mercator},
-    {"-m mercator -p '-P udp -d 54321' 192.0.2.1", mercator_54321},    
+    {"-m mercator -p '-P udp -d 54321' 192.0.2.1", mercator_54321},
     /* bump needs two probedefs */
     {"-m bump 192.0.2.1 192.0.2.2", isnull},
     {"-m bump -p '-P udp' 192.0.2.1 192.0.2.2", isnull},

--- a/tests/unit_cmd_host.c
+++ b/tests/unit_cmd_host.c
@@ -1,7 +1,7 @@
 /*
  * unit_cmd_host : unit tests for host commands
  *
- * $Id: unit_cmd_host.c,v 1.4 2024/02/14 08:05:55 mjl Exp $
+ * $Id: unit_cmd_host.c,v 1.5 2024/04/28 20:10:19 mjl Exp $
  *
  *        Matthew Luckie
  *        mjl@luckie.org.nz
@@ -104,6 +104,68 @@ static int ns_example_com_ns_R_1(const scamper_host_t *in)
   return 0;
 }
 
+static int example_com_txt_T(const scamper_host_t *in)
+{
+  const char *qname;
+
+  if(in == NULL ||
+     check_addr(scamper_host_dst_get(in), "192.0.2.2") != 0 ||
+     (qname = scamper_host_qname_get(in)) == NULL ||
+     strcmp(qname, "example.com") != 0 ||
+     scamper_host_qclass_get(in) != SCAMPER_HOST_CLASS_IN ||
+     scamper_host_qtype_get(in) != SCAMPER_HOST_TYPE_TXT ||
+     (scamper_host_flags_get(in) & SCAMPER_HOST_FLAG_TCP) == 0)
+    return -1;
+
+  return 0;
+}
+
+static int example_com_aaaa_r(const scamper_host_t *in)
+{
+  const char *qname;
+
+  if(in == NULL ||
+     check_addr(scamper_host_dst_get(in), "192.0.2.2") != 0 ||
+     (qname = scamper_host_qname_get(in)) == NULL ||
+     strcmp(qname, "example.com") != 0 ||
+     scamper_host_qclass_get(in) != SCAMPER_HOST_CLASS_IN ||
+     scamper_host_qtype_get(in) != SCAMPER_HOST_TYPE_AAAA ||
+     (scamper_host_flags_get(in) & SCAMPER_HOST_FLAG_NORECURSE) == 0)
+    return -1;
+
+  return 0;
+}
+
+static int example_com_soa(const scamper_host_t *in)
+{
+  const char *qname;
+
+  if(in == NULL ||
+     check_addr(scamper_host_dst_get(in), "192.0.2.2") != 0 ||
+     (qname = scamper_host_qname_get(in)) == NULL ||
+     strcmp(qname, "example.com") != 0 ||
+     scamper_host_qclass_get(in) != SCAMPER_HOST_CLASS_IN ||
+     scamper_host_qtype_get(in) != SCAMPER_HOST_TYPE_SOA)
+    return -1;
+
+  return 0;
+}
+
+static int x192_0_2_55_ptr(const scamper_host_t *in)
+{
+  const char *qname;
+
+  if(in == NULL ||
+     check_addr(scamper_host_dst_get(in), "192.0.2.2") != 0 ||
+     (qname = scamper_host_qname_get(in)) == NULL ||
+     strcmp(qname, "192.0.2.55") != 0 ||
+     scamper_host_qclass_get(in) != SCAMPER_HOST_CLASS_IN ||
+     scamper_host_qtype_get(in) != SCAMPER_HOST_TYPE_PTR)
+    return -1;
+
+  return 0;
+}
+
 static int check(const char *cmd, int (*func)(const scamper_host_t *in))
 {
   scamper_host_t *host;
@@ -148,6 +210,7 @@ int main(int argc, char *argv[])
 {
   sc_test_t tests[] = {
     {"-s 192.0.2.1 example.com", example_com_a},
+    {"-s 192.0.2.1 -t a example.com", example_com_a},
     {"-s 192.0.2.1 -t mx -W 1.5 mail.example.com", mail_example_com_mx_w_1_5},
     {"-s 192.0.2.1 -t mx -W 1.500 mail.example.com", mail_example_com_mx_w_1_5},
     {"-s 192.0.2.1 -t mx -W 1.5001 mail.example.com", isnull},
@@ -156,6 +219,11 @@ int main(int argc, char *argv[])
     {"-s 192.0.2.1 -t mx -W 1.5001s mail.example.com", isnull},
     {"-s 192.0.2.1 -t mx -W 1500ms mail.example.com", mail_example_com_mx_w_1_5},
     {"-s 192.0.2.2 -t ns -R 1 ns.example.com", ns_example_com_ns_R_1},
+    {"-s 192.0.2.2 -t txt -T example.com", example_com_txt_T},
+    {"-s 192.0.2.2 -t soa example.com", example_com_soa},
+    {"-s 192.0.2.2 -t aaaa -r example.com", example_com_aaaa_r},
+    {"-s 192.0.2.2 192.0.2.55", x192_0_2_55_ptr},
+    {"-s 192.0.2.2 -t ptr 192.0.2.55", x192_0_2_55_ptr},
   };
   size_t i, testc = sizeof(tests) / sizeof(sc_test_t);
   char filename[128];

--- a/tests/unit_cmd_trace.c
+++ b/tests/unit_cmd_trace.c
@@ -1,7 +1,7 @@
 /*
  * unit_cmd_trace : unit tests for trace commands
  *
- * $Id: unit_cmd_trace.c,v 1.12 2024/02/14 07:36:37 mjl Exp $
+ * $Id: unit_cmd_trace.c,v 1.13 2024/03/04 19:36:41 mjl Exp $
  *
  *        Matthew Luckie
  *        mjl@luckie.org.nz
@@ -153,13 +153,13 @@ static int do_pmtud(scamper_trace_t *trace)
     return -1;
   return 0;
 }
-	  
+
 static int squeries_4_gaplimit_6(scamper_trace_t *trace)
 {
   if(trace == NULL ||
      check_wait_probe_def(trace) != 0 || check_wait_timeout_def(trace) != 0 ||
      scamper_trace_squeries_get(trace) != 4 ||
-     scamper_trace_gaplimit_get(trace) != 6) 
+     scamper_trace_gaplimit_get(trace) != 6)
     return -1;
   return 0;
 }

--- a/tests/unit_dl_parse_arp.c
+++ b/tests/unit_dl_parse_arp.c
@@ -1,0 +1,147 @@
+/*
+ * unit_dl_parse_arp : unit tests for dl_parse_arp function
+ *
+ * $Id: unit_dl_parse_arp.c,v 1.1 2024/07/02 00:50:12 mjl Exp $
+ *
+ *        Matthew Luckie
+ *        mjl@luckie.org.nz
+ *
+ * Copyright (C) 2024 Matthew Luckie
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "internal.h"
+
+#include "scamper_addr.h"
+#include "scamper_dl.h"
+#include "common.h"
+#include "utils.h"
+
+/*
+ * function prototype of a normally static function that is not in
+ * scamper_dl.h
+ */
+int dl_parse_arp(scamper_dl_rec_t *dl, uint8_t *pktbuf, size_t pktlen);
+
+typedef struct sc_test
+{
+  char *pkt;
+  int (*func)(uint8_t *pkt, size_t len);
+} sc_test_t;
+
+static int empty(uint8_t *pkt, size_t len)
+{
+  scamper_dl_rec_t dl;
+  memset(&dl, 0, sizeof(dl));
+  if(dl_parse_arp(&dl, pkt, len) != 0)
+    return -1;
+  return 0;
+}
+
+static int whohas(uint8_t *pkt, size_t len)
+{
+  scamper_dl_rec_t dl;
+  memset(&dl, 0, sizeof(dl));
+  if(dl_parse_arp(&dl, pkt, len) == 0 ||
+     SCAMPER_DL_IS_ARP_OP_REQ(&dl) == 0 ||
+     SCAMPER_DL_IS_ARP_HRD_ETHERNET(&dl) == 0 ||
+     SCAMPER_DL_IS_ARP_PRO_IPV4(&dl) == 0)
+    return -1;
+  return 0;
+}
+
+static int isat(uint8_t *pkt, size_t len)
+{
+  scamper_dl_rec_t dl;
+  memset(&dl, 0, sizeof(dl));
+  if(dl_parse_arp(&dl, pkt, len) == 0 ||
+     SCAMPER_DL_IS_ARP_OP_REPLY(&dl) == 0 ||
+     SCAMPER_DL_IS_ARP_HRD_ETHERNET(&dl) == 0 ||
+     SCAMPER_DL_IS_ARP_PRO_IPV4(&dl) == 0)
+    return -1;
+  return 0;
+}
+
+static int check(const char *pkt, int (*func)(uint8_t *pkt, size_t len))
+{
+  size_t len;
+  uint8_t *buf = NULL;
+  int rc = -1;
+
+  if(hex2buf(pkt, &buf, &len) != 0)
+    goto done;
+
+  rc = func(buf, len);
+
+ done:
+  if(buf != NULL) free(buf);
+  return rc;
+}
+
+int main(int argc, char *argv[])
+{
+  sc_test_t tests[] = {
+    {"",
+     empty},
+    {"0001080006040001"
+     "dca632057787c0a8031b"
+     "000000000000c0a8032a"
+     "00000000000000000000"
+     "0000000000000000",
+     whohas},
+    {"0001080006040002"
+     "848bcd4afbe6c0a80301"
+     "b619ed518334c0a8032a",
+     isat},
+  };
+  size_t i, testc = sizeof(tests) / sizeof(sc_test_t);
+  char filename[128];
+
+  /* dump packets if requested */
+  if(argc == 3 && strcasecmp(argv[1], "dump") == 0)
+    {
+      for(i=0; i<testc; i++)
+	{
+	  snprintf(filename, sizeof(filename),
+		   "%s/pkt-%03x.dat", argv[2], (int)i);
+	  if(dump_hex(tests[i].pkt, filename) != 0)
+	    break;
+	}
+    }
+  else if(argc == 1)
+    {
+      for(i=0; i<testc; i++)
+	if(check(tests[i].pkt, tests[i].func) != 0)
+	  break;
+    }
+  else
+    {
+      printf("invalid usage\n");
+      return -1;
+    }
+
+  if(i != testc)
+    {
+      printf("test %d failed\n", (int)i);
+      return -1;
+    }
+
+  printf("OK\n");
+  return 0;
+}

--- a/tests/unit_fds.c
+++ b/tests/unit_fds.c
@@ -1,7 +1,7 @@
 /*
  * unit_fds : unit tests for scamper_fd
  *
- * $Id: unit_fds.c,v 1.4 2024/02/27 08:14:29 mjl Exp $
+ * $Id: unit_fds.c,v 1.6 2024/07/15 22:17:36 mjl Exp $
  *
  *        Matthew Luckie
  *        mjl@luckie.org.nz
@@ -234,7 +234,7 @@ static int test_0(void)
 
   /*
    * scamper_fd_addr should only work on IP sockets, and should only
-   * return 0 to signify it is not bound to any address 
+   * return 0 to signify it is not bound to any address
    */
   if(scamper_fd_addr(fds[0], &in4, sizeof(in4)) != 0 ||       /* udp4dg */
      scamper_fd_addr(fds[1], &in4, sizeof(in4)) != 0 ||       /* tcp4 */
@@ -315,6 +315,55 @@ static int test_1(void)
   return -1;
 }
 
+static int test_2(void)
+{
+  scamper_fd_t *fds[10];
+  size_t i;
+  uint16_t *ports = NULL;
+  uint16_t *u4, *u6, *t4, *t6, u4c, u6c, t4c, t6c;
+  int rc = -1;
+
+  memset(fds, 0, sizeof(fds));
+
+  if((fds[0] = scamper_fd_udp4dg(NULL, 38421)) == NULL ||
+     (fds[1] = scamper_fd_udp6(NULL, 12492)) == NULL ||
+     (fds[2] = scamper_fd_tcp4(NULL, 51745)) == NULL ||
+     (fds[3] = scamper_fd_tcp6(NULL, 24531)) == NULL ||
+     (fds[4] = scamper_fd_udp4dg(NULL, 44258)) == NULL ||
+     (fds[5] = scamper_fd_udp6(NULL, 52532)) == NULL ||
+     (fds[6] = scamper_fd_tcp4(NULL, 543)) == NULL ||
+     (fds[7] = scamper_fd_tcp6(NULL, 31315)) == NULL ||
+     (fds[8] = scamper_fd_udp4dg(NULL, 12345)) == NULL ||
+     (fds[9] = scamper_fd_udp6(NULL, 42152)) == NULL)
+    goto done;
+
+  if(scamper_fds_sports(&ports, &i) != 0)
+    goto done;
+  if(i != 4 + 10)
+    goto done;
+  u4 = ports+4;  u4c = ports[0]; if(u4c != 3) goto done;
+  t4 = u4 + u4c; t4c = ports[1]; if(t4c != 2) goto done;
+  u6 = t4 + t4c; u6c = ports[2]; if(u6c != 3) goto done;
+  t6 = u6 + u6c; t6c = ports[3]; if(t6c != 2) goto done;
+
+  if(u4[0] != 38421 || u4[1] != 44258 || u4[2] != 12345)
+    goto done;
+  if(t4[0] != 51745 || t4[1] != 543)
+    goto done;
+  if(u6[0] != 12492 || u6[1] != 52532 || u6[2] != 42152)
+    goto done;
+  if(t6[0] != 24531 || t6[1] != 31315)
+    goto done;
+
+  rc = 0;
+ done:
+  for(i=0; i<10; i++)
+    if(fds[i] != NULL) scamper_fd_free(fds[i]);
+  if(ports != NULL)
+    free(ports);
+  return rc;
+}
+
 static int check(int id, int (*func)(void))
 {
   int rc;
@@ -328,7 +377,8 @@ static int check(int id, int (*func)(void))
   fd_n = 4;
 
   scamper_fds_init();
-  rc = func();
+  if((rc = func()) != 0)
+    printf("fail: %d\n", id);
   scamper_fds_cleanup();
 
 #ifdef DMALLOC
@@ -348,6 +398,7 @@ int main(int argc, char *argv[])
   static int (*const tests[])(void) = {
     test_0,
     test_1,
+    test_2,
   };
   int i, testc = sizeof(tests) / sizeof(void *);
 

--- a/tests/unit_http_lib.c
+++ b/tests/unit_http_lib.c
@@ -1,7 +1,7 @@
 /*
  * unit_http_lib: unit tests for http library
  *
- * $Id: unit_http_lib.c,v 1.2 2023/10/26 04:55:29 mjl Exp $
+ * $Id: unit_http_lib.c,v 1.3 2024/03/04 19:36:41 mjl Exp $
  *
  *        Matthew Luckie
  *        mjl@luckie.org.nz
@@ -39,7 +39,7 @@ static scamper_http_buf_t *htb_make(uint8_t dir, uint8_t type,
 				    const char *data, uint16_t len)
 {
   scamper_http_buf_t *htb;
-  
+
   if((htb = scamper_http_buf_alloc()) == NULL ||
      (htb->data = memdup(data, len)) == NULL)
     goto err;

--- a/tests/unit_string.c
+++ b/tests/unit_string.c
@@ -1,0 +1,134 @@
+/*
+ * unit_timeval: unit tests for string_* functions in utils.c
+ *
+ * $Id: unit_string.c,v 1.2 2024/04/28 20:09:52 mjl Exp $
+ *
+ *        Matthew Luckie
+ *        mjl@luckie.org.nz
+ *
+ * Copyright (C) 2024 Matthew Luckie
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "internal.h"
+
+#include "utils.h"
+
+typedef struct sc_byte2hex_test
+{
+  uint8_t  bytes[4];
+  size_t   bytes_len;
+  size_t   buf_len;
+  size_t   off_in;
+  size_t   off_out;
+  char    *str;
+} sc_byte2hex_test_t;
+
+typedef struct sc_jsonesc_test
+{
+  const char *in;
+  const char *out;
+  size_t      len_in;
+  size_t      len_out;
+} sc_jsonesc_test_t;
+
+static int byte2hex_tests(void)
+{
+  sc_byte2hex_test_t tests[] = {
+    {{0xff, 0xab, 0xcd, 0x01}, 4, 9, 0, 8, "ffabcd01"},
+    {{0xff, 0xab, 0xcd, 0x01}, 0, 9, 0, 0, ""},
+    {{0xff, 0xab, 0xcd, 0x01}, 4, 0, 0, 0, "###########"},
+    {{0xff, 0xab, 0xcd, 0x01}, 4, 7, 0, 6, "ffabcd"},
+    {{0xff, 0xab, 0xcd, 0x01}, 4, 6, 0, 4, "ffab"},
+    {{0xff, 0xab, 0xcd, 0x01}, 4, 12, 2, 10, "##ffabcd01"},
+    {{0xff, 0xab, 0xcd, 0x01}, 4, 12, 13, 13, NULL},
+  };
+  size_t i, testc = sizeof(tests) / sizeof(sc_byte2hex_test_t);
+  size_t off;
+  char buf[12];
+  char *rc;
+
+  for(i=0; i<testc; i++)
+    {
+      /* set the output buf to ##### */
+      memset(buf, 35, sizeof(buf));
+      buf[sizeof(buf)-1] = '\0';
+
+      /* run the test */
+      off = tests[i].off_in;
+      rc = string_byte2hex(buf, tests[i].buf_len, &off,
+			   tests[i].bytes, tests[i].bytes_len);
+      if(off != tests[i].off_out ||
+	 (rc == NULL && tests[i].str != NULL) ||
+	 (rc != NULL && (tests[i].str == NULL || strcmp(rc, tests[i].str) != 0)))
+	{
+	  printf("byte2hex fail %d %d %d %p\n",
+		 (int)i, (int)off, (int)tests[i].off_out, rc);
+	  return -1;
+	}
+    }
+
+  return 0;
+}
+
+static int jsonesc_tests(void)
+{
+  sc_jsonesc_test_t tests[] = {
+    {"foo", "foo", 4, 4},
+    {"test\"", "test\\\"", 7, 7},
+    {"foo", "fo", 3, 4},
+    {"test\"", "test", 5, 7},
+    {"foo", NULL, 0, 4},
+    {"bar\\", "bar\\\\", 6, 6},
+  };
+  size_t i, l, testc = sizeof(tests) / sizeof(sc_jsonesc_test_t);
+  char buf[12], *rc;
+
+  for(i=0; i<testc; i++)
+    {
+      l = json_esc_len(tests[i].in);
+      if(l != tests[i].len_out)
+	{
+	  printf("jsonesc fail %d %d != %d\n", (int)i,
+		 (int)l, (int)tests[i].len_out);
+	  return -1;
+	}
+
+      rc = json_esc(tests[i].in, buf, tests[i].len_in);
+      if((rc == NULL && tests[i].out != NULL) ||
+	 (rc != NULL && (tests[i].out == NULL || strcmp(rc, tests[i].out) != 0)))
+	{
+	  printf("jsonesc fail %d %p \"%s\"\n", (int)i, rc,
+		 rc == NULL ? "<null>" : rc);
+	  return -1;
+	}
+    }
+
+  return 0;
+}
+
+int main(int argc, char *argv[])
+{
+  if(byte2hex_tests() != 0 ||
+     jsonesc_tests() != 0)
+    return -1;
+
+  printf("OK\n");
+  return 0;
+}

--- a/tests/unit_timeval.c
+++ b/tests/unit_timeval.c
@@ -1,7 +1,7 @@
 /*
  * unit_timeval: unit tests for timeval_* functions in utils.c
  *
- * $Id: unit_timeval.c,v 1.1 2024/02/20 21:05:14 mjl Exp $
+ * $Id: unit_timeval.c,v 1.2 2024/03/05 08:03:42 mjl Exp $
  *
  *        Matthew Luckie
  *        mjl@luckie.org.nz
@@ -48,6 +48,15 @@ typedef struct sc_fromstr_test
   time_t      finish_sec;
   suseconds_t finish_usec;
 } sc_fromstr_test_t;
+
+typedef struct sc_cmp_test
+{
+  time_t      a_sec;
+  suseconds_t a_usec;
+  time_t      b_sec;
+  suseconds_t b_usec;
+  int         rc;
+} sc_cmp_test_t;
 
 int fromstr_tests(void)
 {
@@ -143,10 +152,35 @@ int sub_tests(void)
   return 0;
 }
 
+int cmp_tests(void)
+{
+  sc_cmp_test_t tests[] = {
+    {1708459200, 100000, 1708459201, 100000, -1},
+  };
+  size_t i, testc = sizeof(tests) / sizeof(sc_cmp_test_t);
+  struct timeval a, b;
+
+  for(i=0; i<testc; i++)
+    {
+      a.tv_sec  = tests[i].a_sec;
+      a.tv_usec = tests[i].a_usec;
+      b.tv_sec  = tests[i].b_sec;
+      b.tv_usec = tests[i].b_usec;
+      if(timeval_cmp(&a, &b) != tests[i].rc)
+	{
+	  printf("cmp fail %lu\n", i);
+	  return -1;
+	}
+    }
+
+  return 0;
+}
+
 int main(int argc, char *argv[])
 {
   if(fromstr_tests() != 0 ||
-     sub_tests() != 0)
+     sub_tests() != 0 ||
+     cmp_tests() != 0)
     return -1;
 
   printf("OK\n");

--- a/utils.h
+++ b/utils.h
@@ -1,12 +1,12 @@
 /*
  * utils.h
  *
- * $Id: utils.h,v 1.155 2024/02/20 21:02:50 mjl Exp $
+ * $Id: utils.h,v 1.161 2024/06/25 06:03:55 mjl Exp $
  *
  * Copyright (C) 2004-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
  * Copyright (C) 2012-2014 The Regents of the University of California
- * Copyright (C) 2015-2023 Matthew Luckie
+ * Copyright (C) 2015-2024 Matthew Luckie
  * Author: Matthew Luckie
  *
  * This program is free software; you can redistribute it and/or modify
@@ -62,9 +62,9 @@
  */
 int timeval_cmp(const struct timeval *a, const struct timeval *b)
   ATTRIBUTE_NONNULL_PURE;
-int timeval_cmp_lt(const struct timeval *tv, time_t s, uint32_t us)
+int timeval_cmp_lt(const struct timeval *tv, time_t s, suseconds_t us)
   ATTRIBUTE_NONNULL_PURE;
-int timeval_cmp_gt(const struct timeval *tv, time_t s, uint32_t us)
+int timeval_cmp_gt(const struct timeval *tv, time_t s, suseconds_t us)
   ATTRIBUTE_NONNULL_PURE;
 
 int timeval_inrange_us(const struct timeval *a, const struct timeval *b, int c)
@@ -181,7 +181,7 @@ void addr6_add(struct in6_addr *out,
 	       const struct in6_addr *x, const struct in6_addr *y)
   ATTRIBUTE_NONNULL;
 int addr6_add_netlen(struct in6_addr *in, int netlen)
-  ATTRIBUTE_NONNULL;  
+  ATTRIBUTE_NONNULL;
 void addr6_sub(struct in6_addr *out,
 	       const struct in6_addr *y, const struct in6_addr *x)
   ATTRIBUTE_NONNULL;
@@ -200,7 +200,7 @@ int sockaddr_compose_str(struct sockaddr *sa, const char *ip, int port)
   ATTRIBUTE_NONNULL;
 int sockaddr_len(const struct sockaddr *sa)
   ATTRIBUTE_NONNULL_PURE;
-char *sockaddr_tostr(const struct sockaddr *sa, char *buf, size_t len)
+char *sockaddr_tostr(const struct sockaddr *sa, char *buf, size_t len, int with_port)
   ATTRIBUTE_NONNULL;
 
 /*
@@ -208,6 +208,9 @@ char *sockaddr_tostr(const struct sockaddr *sa, char *buf, size_t len)
  */
 int fcntl_set(int fd, int flags);
 int fcntl_unset(int fd, int flags);
+
+int setsockopt_raise(int fd, int lvl, int opt, int val);
+int setsockopt_int(int fd, int lvl, int opt, int val);
 
 /* get the source port that a socket is bound to */
 #ifndef _WIN32 /* SOCKET vs int on windows */
@@ -250,6 +253,9 @@ char *string_concat(char *str, size_t len, size_t *off, const char *fs, ...)
 #else
 char *string_concat(char *str, size_t len, size_t *off, const char *fs, ...);
 #endif
+char *string_byte2hex(char *str, size_t len, size_t *off,
+		      const uint8_t *b, size_t bl) ATTRIBUTE_NONNULL;
+
 const char *string_findlc(const char *str, const char *find)
   ATTRIBUTE_NONNULL_PURE;
 int   string_addrport(const char *in, char **addr, int *port)
@@ -260,11 +266,12 @@ int   string_endswith(const char *in, const char *ending)
 #ifndef NDEBUG
 int string_isdash(const char *str) ATTRIBUTE_NONNULL_PURE;
 #else
-#define string_isdash(str)((str)[0] == '-' && (str)[1] == '\0') 
+#define string_isdash(str)((str)[0] == '-' && (str)[1] == '\0')
 #endif
 
 /* escape a string for json output */
 char *json_esc(const char *in, char *out, size_t len) ATTRIBUTE_NONNULL;
+size_t json_esc_len(const char *in) ATTRIBUTE_NONNULL;
 
 /* parse a URL into its components */
 int url_parse(const char *in, uint16_t *port, char **scheme,

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -11,7 +11,13 @@ SUBDIRS+= sc_hoiho
 endif
 
 SUBDIRS+= \
-	sc_ipiddump \
+	sc_ipiddump
+
+if ENABLE_SC_MINRTT
+SUBDIRS+= sc_minrtt
+endif
+
+SUBDIRS+= \
 	sc_pinger \
 	sc_prefixprober \
 	sc_prefixscan \

--- a/utils/sc_ally/sc_ally.c
+++ b/utils/sc_ally/sc_ally.c
@@ -2,7 +2,7 @@
  * sc_ally : scamper driver to collect data on candidate aliases using the
  *           Ally method.
  *
- * $Id: sc_ally.c,v 1.60 2023/09/24 22:35:01 mjl Exp $
+ * $Id: sc_ally.c,v 1.61 2024/03/04 19:36:41 mjl Exp $
  *
  * Copyright (C) 2009-2011 The University of Waikato
  * Copyright (C) 2013-2015 The Regents of the University of California
@@ -1697,7 +1697,7 @@ static void ctrlcb(scamper_inst_t *inst, uint8_t type, scamper_task_t *task,
   else if(type == SCAMPER_CTRL_TYPE_FATAL)
     {
       print("fatal: %s", scamper_ctrl_strerror(scamper_ctrl));
-      goto err;	    
+      goto err;
     }
   return;
 
@@ -1723,7 +1723,7 @@ static int do_scamperconnect(void)
       fprintf(stderr, "could not alloc scamper_ctrl\n");
       return -1;
     }
-  
+
   if(options & OPT_PORT)
     {
       type = "port";

--- a/utils/sc_attach/sc_attach.c
+++ b/utils/sc_attach/sc_attach.c
@@ -21,7 +21,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
- * $Id: sc_attach.c,v 1.41 2024/02/28 04:31:52 mjl Exp $
+ * $Id: sc_attach.c,v 1.42 2024/03/04 19:36:41 mjl Exp $
  *
  */
 
@@ -303,7 +303,7 @@ static int check_options(int argc, char *argv[])
 #endif
 
 	case 'v':
-	  printf("$Id: sc_attach.c,v 1.41 2024/02/28 04:31:52 mjl Exp $\n");
+	  printf("$Id: sc_attach.c,v 1.42 2024/03/04 19:36:41 mjl Exp $\n");
 	  return -1;
 
 	case '?':
@@ -534,7 +534,7 @@ static int do_scamperread_line(void *param, uint8_t *buf, size_t linelen)
   /* feedback letting us know that the command was accepted */
   if(linelen >= 2 && strncasecmp(head, "OK", 2) == 0)
     return 0;
-  
+
   /* if the scamper process is asking for more tasks, give it more */
   if(linelen == 4 && strncasecmp(head, "MORE", linelen) == 0)
     {

--- a/utils/sc_bdrmap/sc_bdrmap.c
+++ b/utils/sc_bdrmap/sc_bdrmap.c
@@ -1,7 +1,7 @@
 /*
  * sc_bdrmap: driver to map first hop border routers of networks
  *
- * $Id: sc_bdrmap.c,v 1.49 2023/12/02 20:43:54 mjl Exp $
+ * $Id: sc_bdrmap.c,v 1.50 2024/04/26 06:52:24 mjl Exp $
  *
  *         Matthew Luckie
  *         mjl@caida.org / mjl@wand.net.nz
@@ -5425,12 +5425,12 @@ static int ip2name_line(char *line, void *param)
 
   ip = line;
   name = line;
-  while(isspace(*name) == 0 && *name != '\0')
+  while(*name != '\0' && isspace((unsigned char)*name) == 0)
     name++;
   if(*name == '\0')
     return 0;
   *name = '\0'; name++;
-  while(isspace(*name) != 0)
+  while(isspace((unsigned char)*name) != 0)
     name++;
 
   if(sa_type == SCAMPER_ADDR_TYPE_IPV4)
@@ -5488,23 +5488,23 @@ static int ip2as_line(char *line, void *param)
   n = line;
 
   m = line;
-  while(isspace(*m) == 0 && *m != '\0')
+  while(*m != '\0' && isspace((unsigned char)*m) == 0)
     m++;
   if(*m == '\0')
     return -1;
   *m = '\0'; m++;
-  while(isspace(*m) != 0)
+  while(isspace((unsigned char)*m) != 0)
     m++;
   if(string_tolong(m, &lo) != 0)
     return -1;
 
   a = m;
-  while(isspace(*a) == 0 && *a != '\0')
+  while(*a != '\0' && isspace((unsigned char)*a) == 0)
     a++;
   if(*a == '\0')
     return -1;
   *a = '\0'; a++;
-  while(isspace(*a) != 0)
+  while(isspace((unsigned char)*a) != 0)
     a++;
 
   if(sa_type == SCAMPER_ADDR_TYPE_IPV4)
@@ -5594,12 +5594,12 @@ static int ipmap_line(char *line, void *param)
   a = line;
 
   /* get the AS number */
-  while(isspace(*a) == 0 && *a != '\0')
+  while(*a != '\0' && isspace((unsigned char)*a) == 0)
     a++;
   if(*a == '\0')
     goto err;
   *a = '\0'; a++;
-  while(isspace(*a) != 0)
+  while(isspace((unsigned char)*a) != 0)
     a++;
   if(string_isnumber(a) == 0 || string_tolong(a, &lo) != 0)
     goto err;

--- a/utils/sc_erosprober/sc_erosprober.c
+++ b/utils/sc_erosprober/sc_erosprober.c
@@ -677,7 +677,7 @@ static int do_ctrlsock_readline(void *param, uint8_t *buf, size_t len)
   if(op == '+' || op == '-')
     {
       line++;
-      while(isspace(*line) != 0 && *line != '\0')
+      while(*line != '\0' && isspace((unsigned char)*line) != 0)
 	line++;
       if(*line == '\0')
 	return 0;

--- a/utils/sc_filterpolicy/sc_filterpolicy.1
+++ b/utils/sc_filterpolicy/sc_filterpolicy.1
@@ -6,7 +6,7 @@
 .\" Copyright (c) 2015 Matthew Luckie
 .\"                    All rights reserved
 .\"
-.\" $Id: sc_filterpolicy.1,v 1.8 2016/07/30 08:09:20 mjl Exp $
+.\" $Id: sc_filterpolicy.1,v 1.9 2024/03/04 19:36:41 mjl Exp $
 .\"
 .Dd December 2, 2015
 .Dt SC_FILTERPOLICY 1
@@ -306,8 +306,8 @@ each router:
 .ft CW
 sc_filterpolicy -r example-routers.warts
 .Pp
-            :        T                  
-            :        e  H               
+            :        T
+            :        e  H
             :  I     l  T  H           S
             :  C  S  n  T  T  B  N  D  N
             :  M  S  e  P  T  G  T  N  M

--- a/utils/sc_minrtt/Makefile.am
+++ b/utils/sc_minrtt/Makefile.am
@@ -1,0 +1,20 @@
+AUTOMAKE_OPTIONS = subdir-objects
+
+AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/scamper
+
+bin_PROGRAMS = sc_minrtt
+
+sc_minrtt_SOURCES = \
+	sc_minrtt.c \
+	../../utils.c \
+	../../mjl_list.c \
+	../../mjl_splaytree.c \
+	../../mjl_threadpool.c
+
+sc_minrtt_CFLAGS = @PTHREAD_CFLAGS@ @PCRE_CFLAGS@
+sc_minrtt_LDFLAGS = @PTHREAD_CFLAGS@ @PCRE_CFLAGS@
+sc_minrtt_LDADD = @PTHREAD_LIBS@ @PCRE_LIBS@ ../../scamper/libscamperfile.la -lsqlite3
+
+man_MANS = sc_minrtt.1
+
+CLEANFILES = *~ *.core

--- a/utils/sc_minrtt/sc_minrtt.1
+++ b/utils/sc_minrtt/sc_minrtt.1
@@ -1,0 +1,172 @@
+.\"
+.\" sc_minrtt.1
+.\"
+.\" Author: Matthew Luckie <mjl@luckie.org.nz>
+.\"
+.\" Copyright (c) 2024 The Regents of the University of California
+.\"               All rights reserved
+.\"
+.\" $Id: sc_minrtt.1,v 1.1 2024/07/09 22:05:41 mjl Exp $
+.\"
+.Dd April 2, 2024
+.Dt SC_MINRTT 1
+.Os
+.Sh NAME
+.Nm sc_minrtt
+.Nd Manage RTT input to sc_hoiho
+.Sh SYNOPSIS
+.Nm
+.Bk -words
+.Op Fl c
+.Op Fl d Ar db-file
+.Ek
+.Pp
+.Nm
+.Bk -words
+.Op Fl i
+.Op Fl d Ar db-file
+.Op Fl R Ar regex
+.Ar
+.Ek
+.Pp
+.Nm
+.Bk -words
+.Op Fl p Ar process-mode
+.Op Fl d Ar db-file
+.Op Fl r Ar router-file
+.Op Fl t Ar threadc
+.Op Fl V Ar vploc-file
+.Ek
+.\""""""""""""
+.Sh DESCRIPTION
+The
+.Nm
+utility processes RTT data collected with
+.Xr sc_pinger 1
+using a series of vantage points into a format for
+.Xr sc_hoiho 1
+to use.
+.Nm
+builds an sqlite3
+database, which it uses to store RTT samples for faster processing.
+The intended workflow using
+.Nm
+is to first create a blank sqlite3 database using
+.Fl c ,
+import the RTT samples from
+.Xr warts 5
+files using
+.Fl i ,
+and then use the database to create the RTT constraints file for
+.Xr sc_hoiho 1
+using
+.Fl p.
+The supported options to
+.Nm
+are as follows:
+.Bl -tag -width Ds
+.It Fl c
+specifies that a sqlite3 database file is to be created.
+.It Fl d Ar db-file
+specifies the name of the sqlite3 database file to use.
+.It Fl i
+specifies that the RTT samples in the supplied
+.Xr warts 5
+files collected with
+.Xr sc_pinger 1
+should be imported into the sqlite3 database.
+.It Fl p Ar process-mode
+specifies the processing to do on the RTT samples, either
+mode 1 or 2.  Mode 1 identifies VPs that might be contributing
+spurious RTT samples.  Mode 2 dumps the minimum set of RTT
+constraints from the collected RTT samples.
+.It Fl r Ar router-file
+specifies the name of a corresponding router file that maps IP
+addresses to routers.
+The format of this file is the same as that supplied to
+.Xr sc_hoiho 1 .
+.It Fl R Ar regex
+specifies the regular expression to apply to input file names that
+extracts a vantage point name.  The extracted vantage point name
+must subsequently match an entry in the vploc file supplied with
+the
+.Fl V
+option when processing the samples.
+.It Fl t Ar threadc
+specifies the number of threads to use when processing the database.
+.It Fl V Ar vploc-file
+specifies a file containing a mapping of vantage point names to lat /
+long coordinates.
+.El
+.\""""""""""""
+.Sh EXAMPLES
+Given a set of warts files named hlz2-nz.pinger.warts,
+ams7-nl.pinger.warts, cld-us.pinger.warts, and a blank database
+created with
+.Pp
+sc_minrtt -c -d minrtt.sqlite
+.Pp
+the following will import the RTT samples:
+.Pp
+sc_minrtt -i -d minrtt.sqlite -R "([a-z]{3}\\d*-[a-z]{2})\\.pinger\\.warts$" /path/to/*.pinger.warts
+.Pp
+To dump the minimum set of RTT values providing constraints per IP address, use:
+.Pp
+sc_minrtt -p 2 -d minrtt.sqlite -v vploc.txt
+.Pp
+To dump the minimum set of RTT values per router for use by
+.Xr sc_hoiho 1 ,
+use:
+.Pp
+sc_minrtt -p 2 -d minrtt.sqlite -v vploc.txt -r routers.txt
+.Pp
+.\""""""""""""
+.Sh NOTES
+.Nm
+records which files it has imported in the database, so that it does
+not re-import the same file multiple times.  It does not store the
+full path to the file, so all filenames need to be unique, even if
+they are stored in different directories.
+.Pp
+.Nm
+organizes entries in a binary blob for each IP address in the sqlite
+database.  It is best to write the database to a file located on a
+.Xr tmpfs 5
+filesystem, and then copy it to disk once it is created.
+.Pp
+.Nm
+attempts to determine responses that are forged by a middle-box close
+to the vantage point by looking for reply-TTL run-lengths involving
+many unique destinations.  Internally, the threshold is a run of 50
+unique destinations with the same reply-TTL run-length.  This feature
+cannot currently be disabled or changed at runtime.
+.Pp
+The format of the vploc.txt file can be one of two supported formats,
+either
+.Pp
+.Dl ams7-nl 52.35 4.82
+.Dl hlz2-nz -37.78 175.17
+.Dl cld-us 32.88 -117.24
+.Pp
+or
+.Pp
+.Dl vp ams7-nl 52.35 4.82
+.Dl vp hlz2-nz -37.78 175.17
+.Dl vp cld-us 32.88 -117.24
+.Pp
+The latter format has the string "vp" at the start of each line, and
+is the same format used by
+.Xr sc_hoiho 1 ,
+so you can supply the same vploc.txt file to both
+.Xr sc_hoiho 1
+and
+.Nm .
+.Sh SEE ALSO
+.Xr sc_hoiho 1 ,
+.Xr sc_pinger 1 ,
+.Xr sqlite3 1
+.Sh AUTHORS
+.Nm
+was written by Matthew Luckie.
+Shivani Hariprasad and Harsh Gondaliya developed code to emit the
+minimum set of RTT constraints per address or router.

--- a/utils/sc_minrtt/sc_minrtt.c
+++ b/utils/sc_minrtt/sc_minrtt.c
@@ -1,0 +1,2423 @@
+/*
+ * sc_minrtt: dump RTT values by node for use by sc_hoiho
+ *
+ * $Id: sc_minrtt.c,v 1.4 2024/07/14 22:40:25 mjl Exp $
+ *
+ *         Matthew Luckie
+ *         mjl@luckie.org.nz
+ *
+ * Copyright (C) 2023-2024 The Regents of the University of California
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "internal.h"
+
+#include <sqlite3.h>
+
+#ifdef HAVE_PCRE2
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+#else
+#include <pcre.h>
+#endif
+
+#ifdef DMALLOC
+#include <dmalloc.h>
+#endif
+
+#ifdef HAVE_PTHREAD
+#include <pthread.h>
+#endif
+
+#include <assert.h>
+
+#include "scamper_addr.h"
+#include "scamper_list.h"
+#include "ping/scamper_ping.h"
+#include "scamper_file.h"
+#include "mjl_list.h"
+#include "mjl_splaytree.h"
+#include "mjl_threadpool.h"
+#include "utils.h"
+
+#define OPT_HELP        0x0001
+#define OPT_DBFILE      0x0002
+#define OPT_CREATE      0x0004
+#define OPT_IMPORT      0x0008
+#define OPT_PROCESS     0x0010
+#define OPT_REGEX       0x0020
+#define OPT_THREADC     0x0040
+#define OPT_VPLOCFILE   0x0080
+#define OPT_RTRFILE     0x0100
+
+/* this is the same order that sc_pinger uses */
+#define RTT_METHOD_ICMP_ECHO  1
+#define RTT_METHOD_UDP        2
+#define RTT_METHOD_TCP_ACK_SP 3
+
+/*
+ * blob size consists of 150 samples and a 2 byte index.  each sample
+ * contains:
+ * - 1 byte method,
+ * - 2 byte VP id,
+ * - 1 byte reply TTL,
+ * - 4 byte RTT
+ */
+#define SAMPLE_SIZE (1 + 2 + 1 + 4)
+#define BLOB_SIZE_MIN ((SAMPLE_SIZE * 150) + 2)
+
+typedef struct sc_vp sc_vp_t;
+
+typedef struct sc_dst
+{
+  scamper_addr_t *addr;
+  sqlite3_int64   id;
+  sqlite3_int64   samples_rowid;
+  uint8_t         flags;
+} sc_dst_t;
+
+typedef struct sc_vpmeth
+{
+  sc_vp_t        *vp;
+  uint8_t         meth;
+  uint16_t        pc;
+  uint32_t        bad, total;
+} sc_vpmeth_t;
+
+struct sc_vp
+{
+  char           *name;
+  sqlite3_int64   id;
+  double          lat, lng;   /* lag / lng */
+  double          latr, lngr; /* radians */
+  uint8_t         loc;
+  uint8_t         bad[4][256];
+  sc_vpmeth_t     meth[4];
+};
+
+typedef struct sc_sample
+{
+  sc_vp_t        *vp;      /* the VP that collected the sample */
+  scamper_addr_t *addr;    /* the address probed */
+  uint8_t         method;  /* which method obtained this sample */
+  uint8_t         skip;    /* should skip this sample */
+  uint8_t         rx_ttl;  /* ttl field of the reply */
+  uint32_t        rtt;     /* rtt, in microseconds */
+  struct timeval  tx;      /* transit time */
+  uint16_t        bad;     /* number of VPs disagreeing with sample */
+} sc_sample_t;
+
+typedef struct sc_rxsec
+{
+  time_t          sec;     /* sec for bucketing samples */
+  slist_t        *list;    /* list of samples */
+} sc_rxsec_t;
+
+typedef struct sc_dstlist
+{
+  scamper_addr_t *addr;    /* the address probed */
+  slist_t        *list;    /* list of samples */
+} sc_dstlist_t;
+
+typedef struct sc_router
+{
+  uint32_t        id;      /* router id */
+  slist_t        *addrs;   /* list of scamper_addr_t */
+} sc_router_t;
+
+typedef struct sc_routerload
+{
+  slist_t        *routers; /* list of sc_router_t */
+  slist_t        *addrs;   /* list of scamper_addr_t */
+  uint32_t        id;      /* node id */
+  uint8_t         gotid;   /* is node id set */
+} sc_routerload_t;
+
+static uint32_t        options  = 0;
+static splaytree_t    *dst_tree = NULL;
+static slist_t        *dst_list = NULL;
+static splaytree_t    *vp_tree  = NULL;
+static sc_vp_t       **vp_array = NULL;
+static int             vp_c     = 0;
+static const char     *dbfile   = NULL;
+static sqlite3        *db       = NULL;
+static const char     *vp_regex = NULL;
+static char          **opt_args = NULL;
+static int             opt_argc = 0;
+static threadpool_t   *tp       = NULL;
+static long            threadc  = -1;
+static const char     *vplocfile = NULL;
+static int             proc_x   = 0;
+static const char     *rtrfile  = NULL;
+
+#ifdef HAVE_PTHREAD
+static pthread_mutex_t db_mutex;
+static uint8_t         db_mutex_o = 0;
+static pthread_mutex_t data_mutex;
+static uint8_t         data_mutex_o = 0;
+#endif
+
+#ifdef HAVE_PCRE2
+static pcre2_code     *vp_pcre = NULL;
+#else
+static pcre           *vp_pcre = NULL;
+#endif
+
+static sqlite3_stmt   *st_vp_ins = NULL;
+static sqlite3_stmt   *st_dst_ins = NULL;
+static sqlite3_stmt   *st_dst_upd = NULL;
+static sqlite3_stmt   *st_runlen_ins = NULL;
+static sqlite3_stmt   *st_sample_ins = NULL;
+static sqlite3_stmt   *st_sample_sel = NULL;
+static sqlite3_stmt   *st_filename_sel = NULL;
+static sqlite3_stmt   *st_filename_ins = NULL;
+static sqlite3_blob   *blob = NULL;
+
+static void usage(uint32_t opt_mask)
+{
+  fprintf(stderr,
+    "usage: sc_minrtt [-c] [-d dbfile]\n"
+    "\n"
+    "       sc_minrtt [-i] [-d dbfile] [-R regex] in1.warts .. inN.warts\n"
+    "\n"
+    "       sc_minrtt [-p mode] [-d dbfile] [-r rtrfile] [-t threadc] [-V vploc]\n"
+    "\n");
+
+  if(opt_mask == 0)
+    {
+      fprintf(stderr, "       sc_minrtt -?\n\n");
+      return;
+    }
+
+  return;
+}
+
+static int check_options(int argc, char *argv[])
+{
+  char *opts = "?cd:ip:r:R:t:V:";
+  char *opt_threadc = NULL;
+  uint32_t u32;
+  long lo;
+  int ch;
+
+  while((ch = getopt(argc, argv, opts)) != -1)
+    {
+      switch(ch)
+	{
+	case 'c':
+	  options |= OPT_CREATE;
+	  break;
+
+	case 'd':
+	  options |= OPT_DBFILE;
+	  dbfile = optarg;
+	  break;
+
+	case 'i':
+	  options |= OPT_IMPORT;
+	  break;
+
+	case 'p':
+	  options |= OPT_PROCESS;
+	  if(string_tolong(optarg, &lo) != 0 || lo < 1 || lo > 2)
+	    {
+	      usage(OPT_PROCESS);
+	      return -1;
+	    }
+	  proc_x = lo;
+	  break;
+
+	case 'r':
+	  options |= OPT_RTRFILE;
+	  rtrfile = optarg;
+	  break;
+
+	case 'R':
+	  options |= OPT_REGEX;
+	  vp_regex = optarg;
+	  break;
+
+	case 't':
+	  options |= OPT_THREADC;
+	  opt_threadc = optarg;
+	  break;
+
+	case 'V':
+	  options |= OPT_VPLOCFILE;
+	  vplocfile = optarg;
+	  break;
+
+	default:
+	  usage(0);
+	  return -1;
+	}
+    }
+
+  if(options == 0)
+    {
+      usage(0);
+      return -1;
+    }
+
+  opt_args = argv + optind;
+  opt_argc = argc - optind;
+
+  /* the database file has to be specified */
+  if((options & OPT_DBFILE) == 0)
+    {
+      usage(OPT_DBFILE);
+      return -1;
+    }
+
+  u32 = OPT_CREATE | OPT_IMPORT | OPT_PROCESS;
+  if(countbits32(options & u32) != 1)
+    {
+      usage(0);
+      return -1;
+    }
+
+  if(options & OPT_IMPORT)
+    {
+      if(vp_regex == NULL)
+	{
+	  usage(OPT_IMPORT | OPT_REGEX);
+	  return -1;
+	}
+    }
+
+  if(options & OPT_PROCESS)
+    {
+      if(vplocfile == NULL)
+	{
+	  usage(OPT_PROCESS | OPT_VPLOCFILE);
+	  return -1;
+	}
+    }
+
+  if(opt_threadc != NULL)
+    {
+      if(string_tolong(opt_threadc, &lo) != 0 || lo < 0)
+	{
+	  usage(OPT_THREADC);
+	  return -1;
+	}
+#ifndef HAVE_PTHREAD
+      if(lo > 1)
+	{
+	  usage(OPT_THREADC);
+	  return -1;
+	}
+#endif
+      threadc = lo;
+    }
+
+  return 0;
+}
+
+static int tree_to_slist(void *ptr, void *entry)
+{
+  if(slist_tail_push((slist_t *)ptr, entry) != NULL)
+    return 0;
+  return -1;
+}
+
+static const char *method_str(uint8_t method)
+{
+  static const char *tbl[] = {"", "icmp-echo", "udp-dport", "tcp-ack-sport"};
+  if(method > 3)
+    return "";
+  return tbl[method];
+}
+
+/*
+ * vp_dist
+ *
+ * return the distance, in meters, between two vantage points.
+ */
+static double vp_dist(sc_vp_t *a, sc_vp_t *b)
+{
+  double radius = 6371008.8, ave_lat, ave_lon, squared;
+  ave_lat = (b->latr - a->latr) / 2.0;
+  ave_lon = (b->lngr - a->lngr) / 2.0;
+  squared =
+    pow(sin(ave_lat), 2) + cos(a->latr) * cos(b->latr) * pow(sin(ave_lon), 2);
+  return 2 * radius * asin(sqrt(squared));
+}
+
+/*
+ * dist2rtt
+ *
+ * return the minimum RTT, in microseconds, expected for the distance,
+ * in meters.
+ */
+static uint32_t dist2rtt(double dist)
+{
+  double d = floor((dist * 2) / 204.190477);
+  return ((uint32_t)d);
+}
+
+/*
+ * rtt2dist
+ *
+ * return the distance limit, in meters, implied by the RTT value,
+ * in microseconds.
+ */
+static double rtt2dist(uint32_t rtt)
+{
+  return (204.190477 * rtt) / 2;
+}
+
+static char *percentage(char *buf, size_t len, uint32_t x, uint32_t y)
+{
+  if(y == 0)
+    snprintf(buf, len, "-");
+  else
+    snprintf(buf, len, "%.1f%%", (float)(x * 100) / y);
+  return buf;
+}
+
+static void sc_router_free(sc_router_t *rtr)
+{
+  if(rtr->addrs != NULL)
+    slist_free_cb(rtr->addrs, (slist_free_t)scamper_addr_free);
+  free(rtr);
+  return;
+}
+
+static int sc_router_finish(sc_routerload_t *rl)
+{
+  sc_router_t *rtr = NULL;
+
+  if(rl->gotid == 0 || slist_count(rl->addrs) == 0)
+    {
+      slist_empty_cb(rl->addrs, (slist_free_t)scamper_addr_free);
+      return 0;
+    }
+
+  if((rtr = malloc_zero(sizeof(sc_router_t))) == NULL ||
+     (rtr->addrs = slist_alloc()) == NULL ||
+     slist_tail_push(rl->routers, rtr) == NULL)
+    goto err;
+
+  slist_concat(rtr->addrs, rl->addrs);
+  rtr->id = rl->id;
+  rl->gotid = 0;
+  return 0;
+
+ err:
+  if(rtr != NULL) sc_router_free(rtr);
+  return -1;
+}
+
+static int rtrfile_line(char *line, void *param)
+{
+  sc_routerload_t *rl = param;
+  scamper_addr_t *addr = NULL;
+  long long ll;
+  char *ip, *ptr;
+
+  if(line[0] == '#')
+    {
+      ptr = line + 1;
+      while(*ptr == ' ')
+	ptr++;
+      if(strncasecmp(ptr, "node2id:", 8) == 0)
+	{
+	  ptr += 8;
+	  while(*ptr == ' ')
+	    ptr++;
+	  if(string_tollong(ptr, &ll, NULL, 10) == 0)
+	    {
+	      rl->id = ll;
+	      rl->gotid = 1;
+	    }
+	}
+      return 0;
+    }
+
+  if(line[0] == '\0')
+    {
+      if(sc_router_finish(rl) != 0)
+	return -1;
+      return 0;
+    }
+
+  ip = line;
+  ptr = line;
+  while(*ptr != '\0' && isspace((unsigned char)*ptr) == 0)
+    ptr++;
+  *ptr = '\0';
+
+  if((addr = scamper_addr_fromstr_unspec(ip)) == NULL ||
+     slist_tail_push(rl->addrs, addr) == NULL)
+    goto err;
+
+  return 0;
+
+ err:
+  return -1;
+}
+
+static int sc_vp_cmp(const sc_vp_t *a, const sc_vp_t *b)
+{
+  return strcasecmp(a->name, b->name);
+}
+
+static int sc_vp_id_cmp(const sc_vp_t *a, const sc_vp_t *b)
+{
+  if(a->id < b->id) return -1;
+  if(a->id > b->id) return  1;
+  return 0;
+}
+
+static sc_vp_t *sc_vp_find(const char *name)
+{
+  sc_vp_t fm; fm.name = (char *)name;
+  return (sc_vp_t *)splaytree_find(vp_tree, &fm);
+}
+
+static sc_vp_t *sc_vp_find_id(uint32_t id)
+{
+  sc_vp_t fm; fm.id = id;
+  return array_find((void **)vp_array, vp_c, &fm, (array_cmp_t)sc_vp_id_cmp);
+}
+
+static void sc_vp_free(sc_vp_t *vp)
+{
+  if(vp->name != NULL) free(vp->name);
+  free(vp);
+  return;
+}
+
+static sc_vp_t *sc_vp_alloc(sqlite3_int64 id, const char *name)
+{
+  sc_vp_t *vp;
+  if((vp = malloc_zero(sizeof(sc_vp_t))) == NULL ||
+     (vp->name = strdup(name)) == NULL)
+    {
+      if(vp != NULL) sc_vp_free(vp);
+      return NULL;
+    }
+  vp->id = id;
+  return vp;
+}
+
+static int sc_vp_insert(sc_vp_t *vp)
+{
+  if(splaytree_insert(vp_tree, vp) == NULL)
+    return -1;
+  return 0;
+}
+
+static int sc_vpmeth_cmp(sc_vpmeth_t *a, sc_vpmeth_t *b)
+{
+  if(a->pc > b->pc) return -1;
+  if(a->pc < b->pc) return  1;
+  return 0;
+}
+
+static int sc_dst_cmp(const sc_dst_t *a, const sc_dst_t *b)
+{
+  return scamper_addr_cmp(a->addr, b->addr);
+}
+
+static sc_dst_t *sc_dst_find(const scamper_addr_t *addr)
+{
+  sc_dst_t fm; fm.addr = (scamper_addr_t *)addr;
+  return (sc_dst_t *)splaytree_find(dst_tree, &fm);
+}
+
+static sc_dst_t *sc_dst_alloc(sqlite3_int64 id, scamper_addr_t *addr)
+{
+  sc_dst_t *dst;
+  if((dst = malloc_zero(sizeof(sc_dst_t))) == NULL)
+    return NULL;
+  dst->addr = addr;
+  dst->id = id;
+  return dst;
+}
+
+static void sc_dst_free(sc_dst_t *dst)
+{
+  if(dst->addr != NULL)
+    scamper_addr_free(dst->addr);
+  free(dst);
+  return;
+}
+
+static void sc_sample_free(sc_sample_t *sample)
+{
+  if(sample->addr != NULL) scamper_addr_free(sample->addr);
+  free(sample);
+  return;
+}
+
+static sc_sample_t *sc_sample_alloc(scamper_addr_t *addr, sc_vp_t *vp,
+				    uint8_t method, uint8_t rxttl, uint32_t rtt)
+{
+  sc_sample_t *sample;
+  if((sample = malloc_zero(sizeof(sc_sample_t))) == NULL)
+    return NULL;
+  if(addr != NULL)
+    sample->addr = scamper_addr_use(addr);
+  sample->vp = vp;
+  sample->method = method;
+  sample->rx_ttl = rxttl;
+  sample->rtt    = rtt;
+  return sample;
+}
+
+static sc_sample_t *sc_sample_add(slist_t *list, sc_vp_t *vp,
+				  scamper_addr_t *addr, uint8_t method,
+				  uint8_t rx_ttl, uint32_t rtt)
+{
+  sc_sample_t *sample = NULL;
+  if((sample = malloc_zero(sizeof(sc_sample_t))) == NULL ||
+     slist_tail_push(list, sample) == NULL)
+    {
+      if(sample != NULL)
+	free(sample);
+      return NULL;
+    }
+  sample->vp = vp;
+  sample->method = method;
+  sample->rtt = rtt;
+  sample->rx_ttl = rx_ttl;
+  if(addr != NULL)
+    sample->addr = scamper_addr_use(addr);
+  return sample;
+}
+
+static int sc_sample_ins_cmp(const sc_sample_t *a, const sc_sample_t *b)
+{
+  if(a->method < b->method) return -1;
+  if(a->method > b->method) return  1;
+  if(a->rx_ttl < b->rx_ttl) return -1;
+  if(a->rx_ttl > b->rx_ttl) return  1;
+  if(a->rtt    < b->rtt)    return -1;
+  if(a->rtt    > b->rtt)    return  1;
+  return 0;
+}
+
+static int sc_sample_rx_cmp(const sc_sample_t *a, const sc_sample_t *b)
+{
+  struct timeval rx_a, rx_b;
+  timeval_add_us(&rx_a, &a->tx, a->rtt);
+  timeval_add_us(&rx_b, &b->tx, b->rtt);
+  return timeval_cmp(&rx_a, &rx_b);
+}
+
+static int sc_sample_bad_cmp(const sc_sample_t *a, const sc_sample_t *b)
+{
+  if(a->bad > b->bad) return -1;
+  if(a->bad < b->bad) return  1;
+  return 0;
+}
+
+static int sc_sample_badskip_cmp(const sc_sample_t *a, const sc_sample_t *b)
+{
+  if(a->skip < b->skip) return -1;
+  if(a->skip > b->skip) return  1;
+  if(a->bad > b->bad) return -1;
+  if(a->bad < b->bad) return  1;
+  return 0;
+}
+
+/*
+ * sc_sample_prune_cmp
+ *
+ * sort samples by minimum RTT, then by VP name (for a repeatable sort).
+ * we use this ordering when pruning.
+ */
+static int sc_sample_prune_cmp(const sc_sample_t *a, const sc_sample_t *b)
+{
+  if(a->rtt < b->rtt) return -1;
+  if(a->rtt > b->rtt) return  1;
+  return strcasecmp(a->vp->name, b->vp->name);
+}
+
+static int sc_sample_bad_zero(sc_sample_t *item, void *param)
+{
+  if(item->skip == 0)
+    item->bad = 0;
+  return 0;
+}
+
+static int sc_sample_intersect(sc_sample_t *a, sc_sample_t *b)
+{
+  double distance, radius1, radius2;
+  double epsilon = 1e-9; // Define a small epsilon value
+
+  /* two circles do not intersect if their centers are close */
+  if(fabs(a->vp->lat - b->vp->lat) < epsilon &&
+     fabs(a->vp->lng - b->vp->lng) < epsilon)
+    return 0;
+
+  /*
+   * calculate the distance between the VPs, and the radius implied by
+   * the samples from each VP
+   */
+  radius1 = rtt2dist(a->rtt);
+  radius2 = rtt2dist(b->rtt);
+  distance = vp_dist(a->vp, b->vp);
+
+  /*
+   * the distance between the VPs is more than the distance implied by
+   * the RTTs, so the circles cannot intersect
+   */
+  if(distance > radius1 + radius2)
+    return 0;
+
+  /* the larger circle entirely encloses the smaller circle */
+  if(distance + fmin(radius1, radius2) < fmax(radius1, radius2))
+    return 0;
+
+  /* the circles intersect */
+  return 1;
+}
+
+static void sc_dstlist_free(sc_dstlist_t *dst)
+{
+  if(dst->addr != NULL) scamper_addr_free(dst->addr);
+  if(dst->list != NULL) slist_free_cb(dst->list, (slist_free_t)sc_sample_free);
+  free(dst);
+  return;
+}
+
+static int sc_dstlist_cmp(const sc_dstlist_t *a, const sc_dstlist_t *b)
+{
+  return scamper_addr_cmp(a->addr, b->addr);
+}
+
+static int sc_dstlist_add(splaytree_t *tree, sc_sample_t *sample)
+{
+  sc_dstlist_t fm, *dst;
+
+  fm.addr = sample->addr;
+  if((dst = splaytree_find(tree, &fm)) == NULL)
+    {
+      if((dst = malloc_zero(sizeof(sc_dstlist_t))) == NULL)
+	return -1;
+      dst->addr = scamper_addr_use(sample->addr);
+      if(splaytree_insert(tree, dst) == NULL ||
+	 (dst->list = slist_alloc()) == NULL)
+	{
+	  sc_dstlist_free(dst);
+	  return -1;
+	}
+    }
+
+  if(slist_tail_push(dst->list, sample) == NULL)
+    return -1;
+  return 0;
+}
+
+static void sc_rxsec_free(sc_rxsec_t *rxs)
+{
+  if(rxs->list != NULL) slist_free(rxs->list);
+  free(rxs);
+  return;
+}
+
+static int sc_rxsec_cmp(const sc_rxsec_t *a, const sc_rxsec_t *b)
+{
+  if(a->sec < b->sec) return -1;
+  if(a->sec > b->sec) return  1;
+  return 0;
+}
+
+static slist_t *sc_rxsec_tolist(splaytree_t *tree)
+{
+  slist_t *out = NULL, *list = NULL;
+  sc_rxsec_t *rxs;
+
+  if((out = slist_alloc()) == NULL || (list = slist_alloc()) == NULL)
+    goto err;
+
+  splaytree_inorder(tree, tree_to_slist, list);
+  while((rxs = slist_head_pop(list)) != NULL)
+    {
+      slist_qsort(rxs->list, (slist_cmp_t)sc_sample_rx_cmp);
+      slist_concat(out, rxs->list);
+    }
+
+  slist_free(list);
+  return out;
+
+ err:
+  if(out != NULL) slist_free(out);
+  if(list != NULL) slist_free(list);
+  return NULL;
+}
+
+static int sc_rxsec_add(splaytree_t **trees, sc_sample_t *sample)
+{
+  sc_rxsec_t fm, *rxsec;
+  struct timeval rx;
+
+  timeval_add_us(&rx, &sample->tx, sample->rtt);
+  fm.sec = rx.tv_sec;
+  if((rxsec = splaytree_find(trees[sample->method], &fm)) == NULL)
+    {
+      if((rxsec = malloc_zero(sizeof(sc_rxsec_t))) == NULL)
+	return -1;
+      rxsec->sec = rx.tv_sec;
+      if(splaytree_insert(trees[sample->method], rxsec) == NULL ||
+	 (rxsec->list = slist_alloc()) == NULL)
+	{
+	  sc_rxsec_free(rxsec);
+	  return -1;
+	}
+    }
+
+  if(slist_tail_push(rxsec->list, sample) == NULL)
+    return -1;
+  return 0;
+}
+
+slist_t *do_rtrfile_read(void)
+{
+  sc_routerload_t rl;
+
+  memset(&rl, 0, sizeof(rl));
+  if((rl.addrs = slist_alloc()) == NULL ||
+     (rl.routers = slist_alloc()) == NULL ||
+     file_lines(rtrfile, rtrfile_line, &rl) != 0 ||
+     (slist_count(rl.addrs) > 0 && sc_router_finish(&rl) != 0))
+    {
+      fprintf(stderr, "could not read %s\n", rtrfile);
+      goto err;
+    }
+
+  slist_free(rl.addrs);
+  return rl.routers;
+
+ err:
+  if(rl.addrs != NULL)
+    slist_free_cb(rl.addrs, (slist_free_t)scamper_addr_free);
+  if(rl.routers != NULL)
+    slist_free_cb(rl.routers, (slist_free_t)sc_router_free);
+  return NULL;
+}
+
+static void do_stmt_final(void)
+{
+  if(st_filename_sel != NULL)
+    {
+      sqlite3_finalize(st_filename_sel);
+      st_filename_sel = NULL;
+    }
+  if(st_filename_ins != NULL)
+    {
+      sqlite3_finalize(st_filename_ins);
+      st_filename_ins = NULL;
+    }
+  if(st_sample_sel != NULL)
+    {
+      sqlite3_finalize(st_sample_sel);
+      st_sample_sel = NULL;
+    }
+  if(st_sample_ins != NULL)
+    {
+      sqlite3_finalize(st_sample_ins);
+      st_sample_ins = NULL;
+    }
+  if(st_runlen_ins != NULL)
+    {
+      sqlite3_finalize(st_runlen_ins);
+      st_runlen_ins = NULL;
+    }
+  if(st_dst_upd != NULL)
+    {
+      sqlite3_finalize(st_dst_upd);
+      st_dst_upd = NULL;
+    }
+  if(st_dst_ins != NULL)
+    {
+      sqlite3_finalize(st_dst_ins);
+      st_dst_ins = NULL;
+    }
+  if(st_vp_ins != NULL)
+    {
+      sqlite3_finalize(st_vp_ins);
+      st_vp_ins = NULL;
+    }
+
+  return;
+}
+
+static int do_dsts_read(void)
+{
+  const char *sql = "select id, addr, samples_rowid from dsts";
+  scamper_addr_t *sa = NULL;
+  sqlite3_stmt *stmt = NULL;
+  sqlite3_int64 id;
+  sqlite3_int64 samples_rowid;
+  sc_dst_t *dst = NULL;
+  const unsigned char *addr;
+  int x, rc = -1;
+
+  if((x = sqlite3_prepare_v2(db,sql,strlen(sql)+1,&stmt,NULL)) != SQLITE_OK)
+    {
+      fprintf(stderr, "%s: could not prepare sql: %s\n", __func__,
+	      sqlite3_errstr(x));
+      goto done;
+    }
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+    {
+      id   = sqlite3_column_int64(stmt, 0);
+      addr = sqlite3_column_text(stmt, 1);
+      samples_rowid = sqlite3_column_int64(stmt, 2);
+
+      if((sa = scamper_addr_fromstr(AF_UNSPEC, (const char *)addr)) == NULL)
+	{
+	  fprintf(stderr, "%s: could not resolve %s\n", __func__, addr);
+	  continue;
+	}
+
+      /* create state so we can map an addr to an id */
+      if((dst = sc_dst_alloc(id, sa)) == NULL)
+	goto done;
+      sa = NULL;
+      dst->samples_rowid = samples_rowid;
+
+      assert(dst_tree != NULL || dst_list != NULL);
+      if(dst_tree != NULL)
+	{
+	  if(splaytree_insert(dst_tree, dst) == NULL)
+	    {
+	      fprintf(stderr, "%s: could not insert %s\n", __func__, addr);
+	      goto done;
+	    }
+	}
+      else if(dst_list != NULL)
+	{
+	  if(slist_tail_push(dst_list, dst) == NULL)
+	    {
+	      fprintf(stderr, "%s: could not insert %s\n", __func__, addr);
+	      goto done;
+	    }
+	}
+
+      dst = NULL;
+    }
+
+  rc = 0;
+
+ done:
+  if(stmt != NULL) sqlite3_finalize(stmt);
+  if(sa != NULL) scamper_addr_free(sa);
+  if(dst != NULL) sc_dst_free(dst);
+  return rc;
+}
+
+static int do_vps_read(void)
+{
+  const char *sql = "select id, name from vps";
+  const unsigned char *name;
+  sqlite3_stmt *stmt = NULL;
+  sqlite3_int64 id;
+  sc_vp_t *vp = NULL;
+  int x, rc = -1;
+
+  if((x = sqlite3_prepare_v2(db,sql,strlen(sql)+1,&stmt,NULL)) != SQLITE_OK)
+    {
+      fprintf(stderr, "%s: could not prepare sql: %s\n", __func__,
+	      sqlite3_errstr(x));
+      goto done;
+    }
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+    {
+      /* create state so we can map an name to an id */
+      id   = sqlite3_column_int64(stmt, 0);
+      name = sqlite3_column_text(stmt, 1);
+      if((vp = sc_vp_alloc(id, (char *)name)) == NULL)
+	goto done;
+      if(sc_vp_insert(vp) != 0)
+	{
+	  fprintf(stderr, "%s: could not insert %s\n", __func__, name);
+	  goto done;
+	}
+      vp = NULL;
+    }
+
+  rc = 0;
+
+ done:
+  if(stmt != NULL) sqlite3_finalize(stmt);
+  if(vp != NULL) sc_vp_free(vp);
+  return rc;
+}
+
+/*
+ * do_sqlite_open
+ *
+ * open the database specified in dbfile.  Ensure the database file
+ * exists before opening if OPT_CREATE is not set.
+ */
+static int do_sqlite_open(void)
+{
+  struct stat sb;
+  int rc;
+
+  /*
+   * before opening the database file, check if it exists.
+   * if the file does not exist, only create the dbfile if we've been told.
+   */
+  rc = stat(dbfile, &sb);
+  if(options & OPT_CREATE)
+    {
+      if(rc == 0 || errno != ENOENT)
+	{
+	  fprintf(stderr,
+		  "%s: will not create db called %s: it already exists\n",
+		  __func__, dbfile);
+	  return -1;
+	}
+    }
+  else
+    {
+      if(rc != 0)
+	{
+	  fprintf(stderr, "%s: db %s does not exist, use -c\n",
+		  __func__, dbfile);
+	  return -1;
+	}
+    }
+
+  if((rc = sqlite3_open(dbfile, &db)) != SQLITE_OK)
+    {
+      fprintf(stderr, "%s: could not open %s: %s\n",
+	      __func__, dbfile, sqlite3_errstr(rc));
+      return -1;
+    }
+
+  return 0;
+}
+
+static int do_create(void)
+{
+  static const char *create_sql[] = {
+    /* VP table */
+    ("create table \"vps\" ("
+     "\"id\" INTEGER PRIMARY KEY, "
+     "\"name\" TEXT UNIQUE NOT NULL)"),
+    /* addresses table */
+    ("create table \"dsts\" ("
+     "\"id\" INTEGER PRIMARY KEY, "
+     "\"addr\" STRING NOT NULL, "
+     "\"samples_rowid\" INTEGER NOT NULL)"),
+    /* samples table */
+    ("create table \"samples\" ("
+     "\"id\" INTEGER PRIMARY KEY, "
+     "\"dst_id\" INTEGER NOT NULL, "
+     "\"data\" BLOB NOT NULL)"),
+    /* runlens table */
+    ("create table \"runlens\" ("
+     "\"vp_id\" INTEGER NOT NULL, "
+     "\"meth_id\" INTEGER NOT NULL, "
+     "\"reply_ttl\" INTEGER NOT NULL, "
+     "\"run_len\" INTEGER NOT NULL)"),
+    /* files table */
+    ("create table \"files\" ("
+     "\"filename\" TEXT UNIQUE NOT NULL)"),
+  };
+  char *errmsg;
+  size_t i;
+
+  for(i=0; i<sizeof(create_sql) / sizeof(char *); i++)
+    {
+      if(sqlite3_exec(db, create_sql[i], NULL, NULL, &errmsg) != SQLITE_OK)
+	{
+	  fprintf(stderr, "%s: could not execute sql: %s\n",
+		  __func__, errmsg);
+	  return -1;
+	}
+    }
+
+  return 0;
+}
+
+static int do_import_blob(sc_dst_t *dst)
+{
+  int x;
+
+  /* insert an empty blob into the database */
+  sqlite3_bind_int64(st_sample_ins, 1, dst->id);
+  if((x = sqlite3_step(st_sample_ins)) != SQLITE_DONE)
+    {
+      fprintf(stderr, "%s: could not insert sample: %s\n",
+	      __func__, sqlite3_errstr(x));
+      return -1;
+    }
+  dst->samples_rowid = sqlite3_last_insert_rowid(db);
+  sqlite3_clear_bindings(st_sample_ins);
+  sqlite3_reset(st_sample_ins);
+
+  /* update the dst entry with the sample rowid */
+  sqlite3_bind_int64(st_dst_upd, 1, dst->samples_rowid);
+  sqlite3_bind_int64(st_dst_upd, 2, dst->id);
+  if((x = sqlite3_step(st_dst_upd)) != SQLITE_DONE)
+    {
+      fprintf(stderr, "%s: could not update dst: %s\n",
+	      __func__, sqlite3_errstr(x));
+      return -1;
+    }
+  sqlite3_clear_bindings(st_dst_upd);
+  sqlite3_reset(st_dst_upd);
+
+  return 0;
+}
+
+static int do_import_runlen(sc_vp_t *vp, uint8_t m, uint8_t rxttl, uint32_t len)
+{
+  int x;
+  sqlite3_bind_int64(st_runlen_ins, 1, vp->id);
+  sqlite3_bind_int64(st_runlen_ins, 2, m);
+  sqlite3_bind_int64(st_runlen_ins, 3, rxttl);
+  sqlite3_bind_int64(st_runlen_ins, 4, len);
+  if((x = sqlite3_step(st_runlen_ins)) != SQLITE_DONE)
+    {
+      fprintf(stderr, "%s: could not insert runlen: %s\n",
+	      __func__, sqlite3_errstr(x));
+      return -1;
+    }
+  sqlite3_clear_bindings(st_runlen_ins);
+  sqlite3_reset(st_runlen_ins);
+  return 0;
+}
+
+static int do_import_dst(sc_dst_t *dst)
+{
+  char buf[128];
+  int x;
+
+  /* insert the address into the database */
+  scamper_addr_tostr(dst->addr, buf, sizeof(buf));
+  sqlite3_bind_text(st_dst_ins, 1, buf, strlen(buf), SQLITE_STATIC);
+  if((x = sqlite3_step(st_dst_ins)) != SQLITE_DONE)
+    {
+      fprintf(stderr, "%s: could not insert dst %s: %s\n",
+	      __func__, buf, sqlite3_errstr(x));
+      return -1;
+    }
+  dst->id = sqlite3_last_insert_rowid(db);
+  sqlite3_clear_bindings(st_dst_ins);
+  sqlite3_reset(st_dst_ins);
+
+  return do_import_blob(dst);
+}
+
+/*
+ * do_import_sample
+ *
+ * uint8_t  method
+ * uint16_t vp_id
+ * uint8_t  reply_ttl
+ * uint32_t rtt
+ */
+static int do_import_sample(sc_dst_t *dst, sc_sample_t *sample)
+{
+  uint8_t buf[SAMPLE_SIZE];
+  uint16_t blob_off;
+  int blob_size;
+  int i, x;
+
+  for(i=0; i<2; i++)
+    {
+      /* get the blob */
+      if(blob != NULL)
+	x = sqlite3_blob_reopen(blob, dst->samples_rowid);
+      else
+	x = sqlite3_blob_open(db, "main", "samples", "data",
+			      dst->samples_rowid, 1, &blob);
+      if(x != SQLITE_OK)
+	{
+	  fprintf(stderr, "%s: could not open blob: %s\n",
+		  __func__, sqlite3_errstr(x));
+	  return -1;
+	}
+
+      /* find out how much space is left */
+      blob_size = sqlite3_blob_bytes(blob);
+      if((x = sqlite3_blob_read(blob, buf, 2, 0)) != SQLITE_OK)
+	{
+	  fprintf(stderr, "%s: could not read 2 bytes at offset 0: %s\n",
+		  __func__, sqlite3_errstr(x));
+	  return -1;
+	}
+      blob_off = bytes_ntohs(buf);
+      if(blob_off == 0)
+	blob_off = 2;
+
+      if(blob_off > blob_size)
+	{
+	  fprintf(stderr, "%s: blob_off > blob_size : %u > %d\n",
+		  __func__, blob_off, blob_size);
+	  return -1;
+	}
+
+      if(blob_size - blob_off >= SAMPLE_SIZE)
+	break;
+
+      if(do_import_blob(dst) != 0)
+	return -1;
+    }
+
+  buf[0] = sample->method;
+  bytes_htons(buf + 1, sample->vp->id);
+  buf[3] = sample->rx_ttl;
+  bytes_htonl(buf + 4, sample->rtt);
+
+  x = sqlite3_blob_write(blob, buf, SAMPLE_SIZE, blob_off);
+  if(x != SQLITE_OK)
+    {
+      fprintf(stderr, "%s: could not write %d bytes at %d: %s\n",
+	      __func__, SAMPLE_SIZE, blob_off, sqlite3_errstr(x));
+      return -1;
+    }
+  blob_off += SAMPLE_SIZE;
+  bytes_htons(buf, blob_off);
+  sqlite3_blob_write(blob, buf, 2, 0);
+  if(x != SQLITE_OK)
+    {
+      fprintf(stderr, "%s: could not update offset: %s\n",
+	      __func__, sqlite3_errstr(x));
+      return -1;
+    }
+
+  return 0;
+}
+
+static char *do_import_extract_vp(const char *filename)
+{
+#ifdef HAVE_PCRE2
+  pcre2_match_data *md = NULL;
+  PCRE2_SIZE *ovector = NULL;
+#else
+  int ovector[6];
+#endif
+
+  size_t len = strlen(filename);
+  char *vp_name = NULL;
+  int x;
+
+#ifdef HAVE_PCRE2
+  if((md = pcre2_match_data_create(2, NULL)) == NULL)
+    goto done;
+  if(pcre2_match(vp_pcre, (PCRE2_SPTR)filename, len, 0, 0, md, NULL) <= 0)
+    {
+      fprintf(stderr, "%s: regex %s did not match %s\n",
+	      __func__, vp_regex, filename);
+      goto done;
+    }
+  ovector = pcre2_get_ovector_pointer(md);
+#else
+  if(pcre_exec(vp_pcre, NULL, filename, len, 0, 0, ovector, 6) <= 0)
+    {
+      fprintf(stderr, "%s: regex %s did not match %s\n",
+	      __func__, vp_regex, filename);
+      goto done;
+    }
+#endif
+
+  len = ovector[2+1] - ovector[2] + 1;
+  if((vp_name = malloc(len)) == NULL)
+    {
+      fprintf(stderr, "%s: could not malloc %d bytes\n", __func__,
+	      (int)len);
+      goto done;
+    }
+  x = ovector[2+1] - ovector[2];
+  memcpy(vp_name, filename + ovector[2], x);
+  vp_name[x] = '\0';
+
+ done:
+#ifdef HAVE_PCRE2
+  if(md != NULL) pcre2_match_data_free(md);
+#endif
+  return vp_name;
+}
+
+static void do_import_file(char *filename)
+{
+  scamper_file_t *file = NULL;
+  scamper_file_filter_t *ffilter = NULL;
+  scamper_ping_t *ping = NULL;
+  scamper_addr_t *ping_dst;
+  sc_sample_t *sample, *rxttl, *start, *ins;
+  char *vp_name = NULL;
+  sc_vp_t *vp = NULL;
+  int begun = 0;
+  scamper_ping_reply_t *reply;
+  splaytree_t *dl_tree = NULL, *rxs_trees[4], *addr_tree = NULL;
+  const struct timeval *reply_rtt, *reply_tx;
+  uint16_t filter_types[] = {
+    SCAMPER_FILE_OBJ_PING,
+  };
+  uint16_t filter_cnt = sizeof(filter_types)/sizeof(uint16_t);
+  uint16_t type, i, reply_count;
+  slist_node_t *sn;
+  sc_dstlist_t *dl = NULL;
+  slist_t *rxs_list = NULL, *dl_list = NULL;
+  uint8_t reply_ttl, method;
+  uint32_t rtt, runlen;
+  uint32_t runlens[4][256];
+  sc_dst_t *dst;
+  void *data;
+  char *ptr;
+  int x, j;
+
+#ifdef HAVE_PTHREAD
+  int locked = 0;
+#endif
+
+  memset(rxs_trees, 0, sizeof(rxs_trees));
+
+  if((vp_name = do_import_extract_vp(filename)) == NULL ||
+     (ffilter = scamper_file_filter_alloc(filter_types, filter_cnt)) == NULL)
+    goto done;
+
+  /* check to see if we have already inserted this file */
+  if((ptr = string_lastof_char(filename, '/')) == NULL)
+    ptr = filename;
+  else if(ptr[1] != '\0')
+    ptr = ptr+1;
+  else
+    {
+      fprintf(stderr, "%s: invalid filename %s\n", __func__, filename);
+      goto done;
+    }
+
+#ifdef HAVE_PTHREAD
+  pthread_mutex_lock(&db_mutex);
+  locked = 1;
+#endif
+
+  sqlite3_clear_bindings(st_filename_sel);
+  sqlite3_reset(st_filename_sel);
+  sqlite3_bind_text(st_filename_sel, 1, ptr, strlen(ptr), SQLITE_STATIC);
+  if((x = sqlite3_step(st_filename_sel)) != SQLITE_DONE)
+    {
+      if(x == SQLITE_ROW)
+	{
+	  fprintf(stderr, "%s: %s already inserted\n", __func__, ptr);
+	  goto done;
+	}
+      fprintf(stderr, "%s: %s bad\n", __func__, ptr);
+      goto done;
+    }
+
+  if((vp = sc_vp_find(vp_name)) == NULL)
+    {
+      if((vp = sc_vp_alloc(0, vp_name)) == NULL)
+	{
+	  fprintf(stderr, "%s: could not malloc vp\n", __func__);
+	  goto done;
+	}
+      sqlite3_bind_text(st_vp_ins, 1, vp_name, strlen(vp_name), SQLITE_STATIC);
+      if((x = sqlite3_step(st_vp_ins)) != SQLITE_DONE)
+	{
+	  fprintf(stderr, "%s: could not insert vp %s: %s\n",
+		  __func__, vp_name, sqlite3_errstr(x));
+	  goto done;
+	}
+      vp->id = sqlite3_last_insert_rowid(db);
+      sqlite3_clear_bindings(st_vp_ins);
+      sqlite3_reset(st_vp_ins);
+      if(sc_vp_insert(vp) != 0)
+	{
+	  fprintf(stderr, "%s: could not insert vp\n", __func__);
+	  goto done;
+	}
+    }
+
+#ifdef HAVE_PTHREAD
+  pthread_mutex_unlock(&db_mutex);
+  locked = 0;
+#endif
+
+  printf("%s\n", vp_name);
+
+  if((file = scamper_file_open(filename, 'r', NULL)) == NULL)
+    {
+      fprintf(stderr, "%s: could not open %s\n", __func__, filename);
+      goto done;
+    }
+
+  if((dl_tree = splaytree_alloc((splaytree_cmp_t)sc_dstlist_cmp)) == NULL ||
+     (rxs_trees[1] = splaytree_alloc((splaytree_cmp_t)sc_rxsec_cmp)) == NULL ||
+     (rxs_trees[2] = splaytree_alloc((splaytree_cmp_t)sc_rxsec_cmp)) == NULL ||
+     (rxs_trees[3] = splaytree_alloc((splaytree_cmp_t)sc_rxsec_cmp)) == NULL)
+    goto done;
+
+  while(scamper_file_read(file, ffilter, &type, &data) == 0)
+    {
+      if(data == NULL)
+	break;
+
+      ping = data;
+      ping_dst = scamper_ping_dst_get(ping);
+      reply_count = scamper_ping_reply_count_get(ping);
+
+      for(i=0; i<reply_count; i++)
+	{
+	  if((reply = scamper_ping_reply_get(ping, i)) == NULL ||
+	     scamper_ping_reply_is_from_target(ping, reply) == 0 ||
+	     (reply_tx = scamper_ping_reply_tx_get(reply)) == NULL ||
+	     (reply_rtt = scamper_ping_reply_rtt_get(reply)) == NULL)
+	    continue;
+
+	  reply_ttl = scamper_ping_reply_ttl_get(reply);
+	  switch(scamper_ping_probe_method_get(ping))
+	    {
+	    case SCAMPER_PING_METHOD_UDP:
+	    case SCAMPER_PING_METHOD_UDP_DPORT:
+	      method = RTT_METHOD_UDP;
+	      break;
+
+	    case SCAMPER_PING_METHOD_ICMP_ECHO:
+	      method = RTT_METHOD_ICMP_ECHO;
+	      break;
+
+	    case SCAMPER_PING_METHOD_TCP_ACK_SPORT:
+	      method = RTT_METHOD_TCP_ACK_SP;
+	      break;
+
+	    default:
+	      continue;
+	    }
+
+	  rtt = (reply_rtt->tv_sec * 1000000) + reply_rtt->tv_usec;
+	  if((sample = sc_sample_alloc(ping_dst, vp, method,
+				       reply_ttl, rtt)) == NULL ||
+	     sc_dstlist_add(dl_tree, sample) != 0)
+	    {
+	      if(sample != NULL) sc_sample_free(sample);
+	      goto done;
+	    }
+	  timeval_cpy(&sample->tx, reply_tx);
+	  if(sc_rxsec_add(rxs_trees, sample) != 0)
+	    goto done;
+	  sample = NULL;
+	}
+
+      scamper_ping_free(ping); ping = NULL;
+    }
+  scamper_file_filter_free(ffilter); ffilter = NULL;
+  scamper_file_close(file); file = NULL;
+
+  /*
+   * order the received packets by their receive time, per method, and
+   * then look for runs of the same received TTL value.  identify the
+   * longest run lengths for each received TTL value.
+   */
+  memset(runlens, 0, sizeof(runlens));
+  if((addr_tree = splaytree_alloc((splaytree_cmp_t)scamper_addr_cmp)) == NULL)
+    goto done;
+  for(i=1; i<4; i++)
+    {
+      if((rxs_list = sc_rxsec_tolist(rxs_trees[i])) == NULL)
+	goto done;
+
+      start = NULL;
+      for(sn=slist_head_node(rxs_list); sn != NULL; sn=slist_node_next(sn))
+	{
+	  rxttl = slist_node_item(sn);
+	  if(start == NULL || start->rx_ttl != rxttl->rx_ttl)
+	    {
+	      runlen = splaytree_count(addr_tree);
+	      if(start != NULL && runlens[i][start->rx_ttl] < runlen)
+		runlens[i][start->rx_ttl] = runlen;
+	      start = rxttl;
+	      splaytree_empty(addr_tree, NULL);
+	    }
+	  if(splaytree_find(addr_tree, rxttl->addr) == NULL &&
+	     splaytree_insert(addr_tree, rxttl->addr) == NULL)
+	    goto done;
+	}
+      runlen = splaytree_count(addr_tree);
+      if(start != NULL && runlens[i][start->rx_ttl] < runlen)
+	runlens[i][start->rx_ttl] = runlen;
+
+      /* cleanup this state */
+      splaytree_empty(addr_tree, NULL);
+      slist_free(rxs_list); rxs_list = NULL;
+      splaytree_free(rxs_trees[i], (splaytree_free_t)sc_rxsec_free);
+      rxs_trees[i] = NULL;
+    }
+
+#ifdef HAVE_PTHREAD
+  pthread_mutex_lock(&db_mutex);
+  locked = 1;
+#endif
+
+  sqlite3_exec(db, "begin", NULL, NULL, NULL); begun = 1;
+
+  for(i=1; i<4; i++)
+    {
+      for(j=0; j<256; j++)
+	{
+	  if(runlens[i][j] == 0)
+	    continue;
+	  if(do_import_runlen(vp, i, j, runlens[i][j]) != 0)
+	    goto done;
+	}
+    }
+
+  if((dl_list = slist_alloc()) == NULL)
+    goto done;
+  splaytree_inorder(dl_tree, tree_to_slist, dl_list);
+  splaytree_free(dl_tree, NULL); dl_tree = NULL;
+  while((dl = slist_head_pop(dl_list)) != NULL)
+    {
+      /* get dst record from database */
+      if((dst = sc_dst_find(dl->addr)) == NULL)
+	{
+	  if((dst = sc_dst_alloc(0, dl->addr)) == NULL)
+	    {
+	      fprintf(stderr, "%s: could not malloc dst\n", __func__);
+	      goto done;
+	    }
+	  scamper_addr_use(dst->addr);
+	  if(splaytree_insert(dst_tree, dst) == NULL)
+	    {
+	      fprintf(stderr, "%s: could not insert dst\n", __func__);
+	      sc_dst_free(dst);
+	      goto done;
+	    }
+
+	  if(do_import_dst(dst) != 0)
+	    goto done;
+	}
+
+      /* insert the shortest RTT value for each method/reply_ttl tuple */
+      slist_qsort(dl->list, (slist_cmp_t)sc_sample_ins_cmp);
+      ins = NULL;
+      for(sn=slist_head_node(dl->list); sn != NULL; sn=slist_node_next(sn))
+	{
+	  sample = slist_node_item(sn);
+	  if(ins != NULL &&
+	     sample->method == ins->method &&
+	     sample->rx_ttl == ins->rx_ttl)
+	    continue;
+	  if(do_import_sample(dst, sample) != 0)
+	    goto done;
+	  ins = sample;
+	}
+
+      sc_dstlist_free(dl); dl = NULL;
+    }
+
+  /* insert the filename */
+  sqlite3_bind_text(st_filename_ins, 1, ptr, strlen(ptr), SQLITE_STATIC);
+  if((x = sqlite3_step(st_filename_ins)) != SQLITE_DONE)
+    {
+      fprintf(stderr, "%s: could not insert filename %s: %s\n",
+	      __func__, ptr, sqlite3_errstr(x));
+      goto done;
+    }
+  sqlite3_clear_bindings(st_filename_ins);
+  sqlite3_reset(st_filename_ins);
+
+  sqlite3_blob_close(blob);
+  blob = NULL;
+
+  sqlite3_exec(db, "commit", NULL, NULL, NULL);
+  begun = 0;
+
+ done:
+  if(begun != 0) sqlite3_exec(db, "rollback", NULL, NULL, NULL);
+#ifdef HAVE_PTHREAD
+  if(locked != 0) pthread_mutex_unlock(&db_mutex);
+#endif
+  if(ping != NULL) scamper_ping_free(ping);
+  if(ffilter != NULL) scamper_file_filter_free(ffilter);
+  if(file != NULL) scamper_file_close(file);
+  if(dl_list != NULL)
+    slist_free_cb(dl_list, (slist_free_t)sc_dstlist_free);
+  if(dl_tree != NULL)
+    splaytree_free(dl_tree, (splaytree_free_t)sc_dstlist_free);
+  if(dl != NULL)
+    sc_dstlist_free(dl);
+  if(addr_tree != NULL)
+    splaytree_free(addr_tree, NULL);
+  for(i=1; i<4; i++)
+    if(rxs_trees[i] != NULL)
+      splaytree_free(rxs_trees[i], (splaytree_free_t)sc_rxsec_free);
+  if(rxs_list != NULL) slist_free(rxs_list);
+  if(vp_name != NULL) free(vp_name);
+  return;
+}
+
+static int do_import(void)
+{
+  const char *sql;
+  char buf[128];
+  int f, x;
+  int rc = -1;
+
+#ifdef HAVE_PCRE2
+  uint32_t n;
+  PCRE2_SIZE erroffset;
+  int errnumber;
+#else
+  const char *error;
+  int erroffset, n;
+#endif
+
+  if((dst_tree = splaytree_alloc((splaytree_cmp_t)sc_dst_cmp)) == NULL ||
+     (vp_tree = splaytree_alloc((splaytree_cmp_t)sc_vp_cmp)) == NULL ||
+     do_dsts_read() != 0 || do_vps_read() != 0)
+    goto done;
+
+#ifdef HAVE_PCRE2
+  if((vp_pcre = pcre2_compile((PCRE2_SPTR)vp_regex, PCRE2_ZERO_TERMINATED, 0,
+			      &errnumber, &erroffset, NULL)) == NULL ||
+     pcre2_pattern_info(vp_pcre, PCRE2_INFO_CAPTURECOUNT, &n) != 0)
+    {
+      fprintf(stderr, "could not compile regex\n");
+      goto done;
+    }
+#else
+  if((vp_pcre = pcre_compile(vp_regex, 0, &error, &erroffset, NULL)) == NULL ||
+     pcre_fullinfo(vp_pcre, NULL, PCRE_INFO_CAPTURECOUNT, &n) != 0)
+    {
+      fprintf(stderr, "could not compile regex\n");
+      goto done;
+    }
+#endif
+
+  /* make sure the regex has one capture element */
+  if(n != 1)
+    {
+      fprintf(stderr, "%s: regex has %d capture element, expect 1\n",
+	      __func__, n);
+      goto done;
+    }
+
+  sql = "insert into dsts(addr, samples_rowid) values(?, 0)";
+  x = sqlite3_prepare_v2(db, sql, strlen(sql)+1, &st_dst_ins, NULL);
+  if(x != SQLITE_OK)
+    {
+      fprintf(stderr, "%s: could not prepare dst_ins sql: %s\n",
+	      __func__, sqlite3_errstr(x));
+      goto done;
+    }
+
+  sql = "update dsts set samples_rowid=? where id=?";
+  x = sqlite3_prepare_v2(db, sql, strlen(sql)+1, &st_dst_upd, NULL);
+  if(x != SQLITE_OK)
+    {
+      fprintf(stderr, "%s: could not prepare sql: %s\n",
+	      __func__, sqlite3_errstr(x));
+      goto done;
+    }
+
+  sql = "insert into vps(name) values(?)";
+  x = sqlite3_prepare_v2(db, sql, strlen(sql)+1, &st_vp_ins, NULL);
+  if(x != SQLITE_OK)
+    {
+      fprintf(stderr, "%s: could not prepare vp_ins sql: %s\n",
+	      __func__, sqlite3_errstr(x));
+      goto done;
+    }
+
+  snprintf(buf, sizeof(buf), "insert into samples(dst_id, data)"
+	   " values(?, zeroblob(%d))", BLOB_SIZE_MIN);
+  x = sqlite3_prepare_v2(db, buf, strlen(buf)+1, &st_sample_ins, NULL);
+  if(x != SQLITE_OK)
+    {
+      fprintf(stderr, "%s: could not prepare sample_ins sql: %s\n",
+	      __func__, sqlite3_errstr(x));
+      goto done;
+    }
+
+  sql = "select filename from files where filename=?";
+  x = sqlite3_prepare_v2(db, sql, strlen(sql)+1, &st_filename_sel, NULL);
+  if(x != SQLITE_OK)
+    {
+      fprintf(stderr, "%s: could not prepare sql: %s\n",
+	      __func__, sqlite3_errstr(x));
+      goto done;
+    }
+
+  sql = "insert into files(filename) values(?)";
+  x = sqlite3_prepare_v2(db, sql, strlen(sql)+1, &st_filename_ins, NULL);
+  if(x != SQLITE_OK)
+    {
+      fprintf(stderr, "%s: could not prepare sql: %s\n",
+	      __func__, sqlite3_errstr(x));
+      goto done;
+    }
+
+  sql = "insert into runlens(vp_id, meth_id, reply_ttl, run_len)"
+    " values(?,?,?,?)";
+  x = sqlite3_prepare_v2(db, sql, strlen(sql)+1, &st_runlen_ins, NULL);
+  if(x != SQLITE_OK)
+    {
+      fprintf(stderr, "%s: could not prepare sql: %s\n",
+	      __func__, sqlite3_errstr(x));
+      goto done;
+    }
+
+#ifdef HAVE_PTHREAD
+  if(threadc == -1)
+    threadc = 2;
+  fprintf(stderr, "using %ld threads\n", threadc);
+#else
+  threadc = 0;
+#endif
+
+  tp = threadpool_alloc(threadc);
+  for(f=0; f<opt_argc; f++)
+    threadpool_tail_push(tp, (threadpool_func_t)do_import_file, opt_args[f]);
+  threadpool_join(tp); tp = NULL;
+
+ done:
+  do_stmt_final();
+  return rc;
+}
+
+static int vploc_file_line(char *line, void *param)
+{
+  double lat = 0.0, lng = 0.0;
+  char *ptr, *end;
+  sc_vp_t *vp;
+
+  if(*line == '#')
+    return 0;
+
+  if(strncasecmp(line, "vp ", 3) == 0)
+    {
+      line = line + 3;
+      while(*line != '\0' && isspace((unsigned char)*line) != 0)
+	line++;
+      if(*line == '\0')
+	goto err;
+    }
+
+  /* VP name */
+  ptr = line;
+  while(*ptr != '\0' && isspace((unsigned char)*ptr) == 0)
+    ptr++;
+  if(*ptr == '\0')
+    goto err;
+  *ptr = '\0';
+  ptr++;
+
+  /* do we have this VP? */
+  if((vp = sc_vp_find(line)) == NULL)
+    return 0;
+
+  /* lat */
+  while(*ptr != '\0' && isspace((unsigned char)*ptr) != 0)
+    ptr++;
+  if(*ptr == '\0')
+    goto err;
+  lat = strtod(ptr, &end);
+  if(ptr == end || (*end != '\0' && isspace((unsigned char)*end) == 0))
+    goto err;
+  ptr = end;
+
+  /* lng */
+  while(*ptr != '\0' && isspace((unsigned char)*ptr) != 0)
+    ptr++;
+  if(*ptr == '\0')
+    goto err;
+  lng = strtod(ptr, &end);
+
+  vp->lat = lat;
+  vp->lng = lng;
+  vp->latr = lat * (M_PI / 180.0);
+  vp->lngr = lng * (M_PI / 180.0);
+  vp->loc = 1;
+
+  return 0;
+
+ err:
+  fprintf(stderr, "malformed line %s\n", line);
+  return -1;
+}
+
+static slist_t *do_read_dst_samples(sc_dst_t *dst)
+{
+  slist_t *samples = NULL;
+  sqlite3_int64 sample_id;
+  uint16_t blob_off, blob_len;
+  int blob_size, blob_bytec = 0;
+  sc_vp_t *vp;
+  uint8_t method, reply_ttl;
+  uint8_t *u8 = NULL;
+  uint32_t rtt, vp_id;
+  char buf[128];
+  int x;
+
+  if((samples = slist_alloc()) == NULL)
+    goto err;
+
+  scamper_addr_tostr(dst->addr, buf, sizeof(buf));
+
+  sqlite3_bind_int64(st_sample_sel, 1, dst->id);
+  while((x = sqlite3_step(st_sample_sel)) == SQLITE_ROW)
+    {
+      sample_id = sqlite3_column_int64(st_sample_sel, 0);
+
+      if(blob != NULL)
+	x = sqlite3_blob_reopen(blob, sample_id);
+      else
+	x = sqlite3_blob_open(db, "main", "samples", "data",
+			      sample_id, 0, &blob);
+      if(x != SQLITE_OK)
+	{
+	  fprintf(stderr, "%s: could not open blob %lld for %s: %s\n",
+		  __func__, sample_id, buf, sqlite3_errstr(x));
+	  goto err;
+	}
+      if((blob_size = sqlite3_blob_bytes(blob)) > blob_bytec)
+	{
+	  if(realloc_wrap((void **)&u8, blob_size) != 0)
+	    {
+	      fprintf(stderr, "%s: could not realloc %d bytes for %s: %s\n",
+		      __func__, blob_size, buf, strerror(errno));
+	      goto err;
+	    }
+	  blob_bytec = blob_size;
+	}
+
+      if((x = sqlite3_blob_read(blob, u8, blob_size, 0)) != SQLITE_OK)
+	{
+	  fprintf(stderr, "%s: could not read blob: %s\n",
+		  __func__, sqlite3_errstr(x));
+	  goto err;
+	}
+
+      blob_off = 2;
+      blob_len = bytes_ntohs(u8);
+      if(blob_len < blob_off)
+	{
+	  fprintf(stderr, "%s: really short blob %u\n", __func__, blob_len);
+	  goto err;
+	}
+
+      for(;;)
+	{
+	  if(blob_off == blob_len)
+	    break;
+	  if(blob_len - blob_off < SAMPLE_SIZE)
+	    {
+	      fprintf(stderr, "%s: short blob: %u\n", __func__,
+		      blob_len - blob_off);
+	      goto err;
+	    }
+
+	  method = u8[blob_off];
+	  vp_id = bytes_ntohs(u8 + blob_off + 1);
+	  reply_ttl = u8[blob_off + 3];
+	  rtt = bytes_ntohl(u8 + blob_off + 4);
+	  blob_off += SAMPLE_SIZE;
+
+	  if((vp = sc_vp_find_id(vp_id)) == NULL ||
+	     vp->bad[method][reply_ttl] != 0)
+	    continue;
+	  if(sc_sample_add(samples, vp, NULL, method, reply_ttl, rtt) == NULL)
+	    goto err;
+	}
+    }
+
+  if(u8 != NULL) free(u8);
+
+  sqlite3_clear_bindings(st_sample_sel);
+  sqlite3_reset(st_sample_sel);
+
+  return samples;
+
+ err:
+  if(samples != NULL) slist_free_cb(samples, (slist_free_t)sc_sample_free);
+  if(u8 != NULL) free(u8);
+  sqlite3_clear_bindings(st_sample_sel);
+  sqlite3_reset(st_sample_sel);
+  return NULL;
+}
+
+static int do_samples_create_index(void)
+{
+  char *errmsg;
+  size_t i;
+  int rc = -1;
+
+  static const char *create_sql[] = {
+     "create index if not exists samples_dst_id on samples(dst_id)",
+  };
+  for(i=0; i<sizeof(create_sql) / sizeof(char *); i++)
+    {
+      if(sqlite3_exec(db, create_sql[i], NULL, NULL, &errmsg) != SQLITE_OK)
+	{
+	  fprintf(stderr, "%s: could not execute sql: %s\n",
+		  __func__, errmsg);
+	  goto done;
+	}
+    }
+
+  rc = 0;
+
+ done:
+  return rc;
+}
+
+static int do_vps_array(void)
+{
+  slist_t *list = NULL;
+  sc_vp_t *vp;
+  int i, rc = -1;
+
+  if((list = slist_alloc()) == NULL)
+    goto done;
+
+  splaytree_inorder(vp_tree, tree_to_slist, list);
+  if(slist_count(list) == 0 ||
+     (vp_array = malloc_zero(sizeof(sc_vp_t *) * slist_count(list))) == NULL)
+    goto done;
+  i = 0;
+  while((vp = slist_head_pop(list)) != NULL)
+    {
+      if(vp->loc == 0)
+	{
+	  fprintf(stderr, "no loc for %s\n", vp->name);
+	  goto done;
+	}
+      vp_array[i++] = vp;
+    }
+  vp_c = i;
+  array_qsort((void **)vp_array, vp_c, (array_cmp_t)sc_vp_id_cmp);
+  rc = 0;
+
+ done:
+  slist_free(list);
+  return rc;
+}
+
+static int do_runlens_read(void)
+{
+  const char *sql =
+    "select vp_id, meth_id, reply_ttl, run_len"
+    " from runlens where run_len >= 50";
+  sqlite3_stmt *stmt = NULL;
+  sqlite3_int64 vp_id, meth_id, reply_ttl, run_len;
+  sc_vp_t *vp;
+  int x, rc = -1;
+
+  if((x = sqlite3_prepare_v2(db,sql,strlen(sql)+1,&stmt,NULL)) != SQLITE_OK)
+    {
+      fprintf(stderr, "%s: could not prepare sql: %s\n", __func__,
+	      sqlite3_errstr(x));
+      goto done;
+    }
+
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+    {
+      vp_id     = sqlite3_column_int64(stmt, 0);
+      meth_id   = sqlite3_column_int64(stmt, 1);
+      reply_ttl = sqlite3_column_int64(stmt, 2);
+      run_len   = sqlite3_column_int64(stmt, 3);
+      if(meth_id < 1 || meth_id > 3 || reply_ttl < 0 || reply_ttl > 255 ||
+	 (vp = sc_vp_find_id(vp_id)) == NULL)
+	{
+	  fprintf(stderr, "%s: invalid runlen\n", __func__);
+	  goto done;
+	}
+      vp->bad[meth_id][reply_ttl] = 1;
+      fprintf(stderr, "filtering %s %s ttl %d run %d\n", vp->name,
+	      method_str(meth_id), (int)reply_ttl, (int)run_len);
+    }
+  rc = 0;
+
+ done:
+  if(stmt != NULL) sqlite3_finalize(stmt);
+  return rc;
+}
+
+static void do_process_1_dst(sc_dst_t *dst)
+{
+  slist_t *samples = NULL;
+  slist_node_t *sn1, *sn2;
+  sc_sample_t *s1, *s2;
+  double dist;
+  uint16_t rtt;
+  char buf[256];
+
+#ifdef HAVE_PTHREAD
+  int locked = 0;
+
+  pthread_mutex_lock(&db_mutex);
+  locked = 1;
+#endif
+
+  samples = do_read_dst_samples(dst);
+
+#ifdef HAVE_PTHREAD
+  pthread_mutex_unlock(&db_mutex);
+  locked = 0;
+#endif
+
+  if(samples == NULL || slist_count(samples) == 0)
+    goto done;
+
+  for(;;)
+    {
+      for(sn1=slist_head_node(samples); sn1 != NULL; sn1=slist_node_next(sn1))
+	{
+	  s1 = slist_node_item(sn1);
+	  if(s1->skip != 0)
+	    continue;
+	  for(sn2=slist_node_next(sn1); sn2 != NULL; sn2=slist_node_next(sn2))
+	    {
+	      s2 = slist_node_item(sn2);
+	      if(s2->skip != 0)
+		continue;
+
+	      dist = vp_dist(s1->vp, s2->vp);
+	      rtt = dist2rtt(dist);
+	      if(s1->rtt + s2->rtt >= rtt)
+		continue;
+	      s1->bad++;
+	      s2->bad++;
+	    }
+	}
+
+      slist_qsort(samples, (slist_cmp_t)sc_sample_badskip_cmp);
+      s1 = slist_head_item(samples);
+      if(s1->bad <= 2)
+	break;
+      for(sn2=slist_head_node(samples); sn2 != NULL; sn2=slist_node_next(sn2))
+	{
+	  s2 = slist_node_item(sn2);
+	  if(s2->bad < s1->bad)
+	    break;
+	  s2->skip = 1;
+	}
+      /* if all samples conflict, then we're done */
+      if(sn2 == NULL)
+	break;
+      slist_foreach(samples, (slist_foreach_t)sc_sample_bad_zero, NULL);
+    }
+
+  slist_qsort(samples, (slist_cmp_t)sc_sample_bad_cmp);
+
+#ifdef HAVE_PTHREAD
+  pthread_mutex_lock(&data_mutex);
+#endif
+
+  scamper_addr_tostr(dst->addr, buf, sizeof(buf));
+  for(sn1=slist_head_node(samples); sn1 != NULL; sn1=slist_node_next(sn1))
+    {
+      s1 = slist_node_item(sn1);
+      s1->vp->meth[s1->method].total++;
+      if(s1->skip != 0)
+	{
+	  printf("%s %s %d %s %.3f:%d\n", buf,
+		 s1->vp->name, s1->bad, method_str(s1->method),
+		 ((double)s1->rtt) / 1000, s1->rx_ttl);
+	  s1->vp->meth[s1->method].bad++;
+	}
+    }
+
+#ifdef HAVE_PTHREAD
+  pthread_mutex_unlock(&data_mutex);
+#endif
+
+ done:
+#ifdef HAVE_PTHREAD
+  assert(locked == 0);
+#endif
+  slist_free_cb(samples, (slist_free_t)sc_sample_free);
+  return;
+}
+
+static int do_process_1(void)
+{
+  const char *sql;
+  slist_t *list = NULL;
+  slist_node_t *sn;
+  sc_dst_t *dst;
+  sc_vp_t *vp;
+  sc_vpmeth_t *worst, *vpm;
+  int i, k, x, rc = -1;
+  char a[8], b[8], c[8];
+
+#ifdef HAVE_PTHREAD
+  if(pthread_mutex_init(&data_mutex, NULL) != 0)
+    return -1;
+  data_mutex_o = 1;
+  if(threadc == -1)
+    {
+      threadc = 1;
+#ifdef _SC_NPROCESSORS_ONLN
+      if((i = sysconf(_SC_NPROCESSORS_ONLN)) > 1)
+	threadc = i;
+#endif
+    }
+  fprintf(stderr, "using %ld threads\n", threadc);
+#else
+  threadc = 0;
+#endif
+
+  if((vp_tree = splaytree_alloc((splaytree_cmp_t)sc_vp_cmp)) == NULL ||
+     do_vps_read() != 0 || file_lines(vplocfile, vploc_file_line, NULL) != 0 ||
+     do_vps_array() != 0 ||
+     do_runlens_read() != 0 ||
+     (dst_list = slist_alloc()) == NULL || do_dsts_read() != 0 ||
+     do_samples_create_index() != 0)
+    goto done;
+
+  sql = "select id from samples where dst_id=?";
+  x = sqlite3_prepare_v2(db, sql, strlen(sql)+1, &st_sample_sel, NULL);
+  if(x != SQLITE_OK)
+    {
+      fprintf(stderr, "%s: could not prepare sql: %s\n", __func__,
+	      sqlite3_errstr(x));
+      goto done;
+    }
+
+  /*
+   * create a list that we're going to use to figure out which VP/methods
+   * are returning spurious results
+   */
+  if((list = slist_alloc()) == NULL)
+    goto done;
+  for(i=0; i<vp_c; i++)
+    {
+      vp = vp_array[i];
+      for(k=1; k<=3; k++)
+	{
+	  vp->meth[k].vp = vp;
+	  vp->meth[k].meth = k;
+	  vp->meth[k].pc = 0;
+	  if(slist_tail_push(list, &vp->meth[k]) == NULL)
+	    goto done;
+	}
+    }
+
+  for(;;)
+    {
+      tp = threadpool_alloc(threadc);
+      for(sn=slist_head_node(dst_list); sn != NULL; sn=slist_node_next(sn))
+	{
+	  dst = slist_node_item(sn);
+	  threadpool_tail_push(tp, (threadpool_func_t)do_process_1_dst, dst);
+	}
+      threadpool_join(tp); tp = NULL;
+
+      for(i=0; i<vp_c; i++)
+	{
+	  vp = vp_array[i];
+	  percentage(a, sizeof(a), vp->meth[1].bad, vp->meth[1].total);
+	  percentage(b, sizeof(b), vp->meth[2].bad, vp->meth[2].total);
+	  percentage(c, sizeof(c), vp->meth[3].bad, vp->meth[3].total);
+	  printf("%s %u/%u %s | %u/%u %s | %u/%u %s\n", vp->name,
+		 vp->meth[1].bad, vp->meth[1].total, a,
+		 vp->meth[2].bad, vp->meth[2].total, b,
+		 vp->meth[3].bad, vp->meth[3].total, c);
+
+	  for(k=1; k<=3; k++)
+	    {
+	      vp->meth[k].pc = 0;
+	      if(vp->meth[k].total > 0)
+		vp->meth[k].pc = (vp->meth[k].bad * 1000) / vp->meth[k].total;
+	    }
+	}
+
+      slist_qsort(list, (slist_cmp_t)sc_vpmeth_cmp);
+      for(sn=slist_head_node(list); sn != NULL; sn=slist_node_next(sn))
+	{
+	  vpm = slist_node_item(sn);
+	  if(vpm->pc == 0)
+	    break;
+	  printf("%s %s %.1f @@@\n", vpm->vp->name, method_str(vpm->meth),
+		 ((float)vpm->pc) / 10);
+	}
+
+      worst = slist_head_item(list);
+      if(worst->pc < 1) /* 0.1% */
+	break;
+
+      for(sn=slist_head_node(list); sn != NULL; sn=slist_node_next(sn))
+	{
+	  vpm = slist_node_item(sn);
+	  if(worst->pc > vpm->pc)
+	    break;
+	  for(i=0; i<256; i++)
+	    vpm->vp->bad[vpm->meth][i] = 1;
+	  printf("%s %s %.1f bad\n", vpm->vp->name, method_str(vpm->meth),
+		 ((float)vpm->pc) / 10);
+	}
+
+      for(i=0; i<vp_c; i++)
+	{
+	  vp = vp_array[i];
+	  for(k=1; k<=3; k++)
+	    vp->meth[k].pc = vp->meth[k].bad = vp->meth[k].total = 0;
+	}
+    }
+
+  rc = 0;
+
+ done:
+  if(blob != NULL)
+    {
+      sqlite3_blob_close(blob);
+      blob = NULL;
+    }
+  if(list != NULL) slist_free(list);
+  return rc;
+}
+
+static int do_process_2_prune(slist_t *pruned, slist_t *samples)
+{
+  slist_node_t *sn, *sn2;
+  sc_sample_t *sample, *m;
+
+  if(slist_count(samples) == 0)
+    return 0;
+
+  /* order samples by RTT, then by VP */
+  slist_qsort(samples, (slist_cmp_t)sc_sample_prune_cmp);
+  for(sn=slist_head_node(samples); sn != NULL; sn=slist_node_next(sn))
+    {
+      /*
+       * determine if the sample at hand intersects with all of the
+       * samples in the pruned list.
+       */
+      sample = slist_node_item(sn);
+      for(sn2=slist_head_node(pruned); sn2 != NULL; sn2=slist_node_next(sn2))
+	{
+	  m = slist_node_item(sn2);
+	  if(sc_sample_intersect(sample, m) == 0)
+	    break;
+	}
+
+      /* if it doesn't intersect with all, then add to the pruned list */
+      if(sn2 == NULL && slist_tail_push(pruned, sample) == NULL)
+	return -1;
+    }
+
+  return 0;
+}
+
+static int do_process_2(void)
+{
+  slist_t *samples = NULL;
+  slist_t *pruned = NULL;
+  slist_t *rtr_list = NULL, *rtr_samples = NULL;
+  slist_node_t *sn, *sn2;
+  const char *sql;
+  scamper_addr_t *addr;
+  sc_router_t *rtr;
+  sc_dst_t *dst;
+  sc_sample_t *sample;
+  int x, rc = -1;
+  char buf[256];
+
+  if((vp_tree = splaytree_alloc((splaytree_cmp_t)sc_vp_cmp)) == NULL ||
+     do_vps_read() != 0 || file_lines(vplocfile, vploc_file_line, NULL) != 0 ||
+     do_vps_array() != 0 ||
+     do_runlens_read() != 0 ||
+     do_samples_create_index() != 0 ||
+     (pruned = slist_alloc()) == NULL)
+    goto done;
+
+  sql = "select id from samples where dst_id=?";
+  x = sqlite3_prepare_v2(db, sql, strlen(sql)+1, &st_sample_sel, NULL);
+  if(x != SQLITE_OK)
+    {
+      fprintf(stderr, "%s: could not prepare sql: %s\n", __func__,
+	      sqlite3_errstr(x));
+      goto done;
+    }
+
+  if(rtrfile != NULL)
+    {
+      if((rtr_list = do_rtrfile_read()) == NULL ||
+	 (rtr_samples = slist_alloc()) == NULL ||
+	 (dst_tree = splaytree_alloc((splaytree_cmp_t)sc_dst_cmp)) == NULL ||
+	 do_dsts_read() != 0)
+	goto done;
+
+      for(sn=slist_head_node(rtr_list); sn != NULL; sn=slist_node_next(sn))
+	{
+	  rtr = slist_node_item(sn);
+	  for(sn2=slist_head_node(rtr->addrs); sn2 != NULL;
+	      sn2=slist_node_next(sn2))
+	    {
+	      addr = slist_node_item(sn2);
+	      if((dst = sc_dst_find(addr)) == NULL)
+		continue;
+	      if((samples = do_read_dst_samples(dst)) == NULL)
+		goto done;
+	      slist_concat(rtr_samples, samples);
+	      slist_free(samples); samples = NULL;
+	    }
+
+	  if(do_process_2_prune(pruned, rtr_samples) != 0)
+	    goto done;
+
+	  while((sample = slist_head_pop(pruned)) != NULL)
+	    printf("N%d %s %d\n", rtr->id, sample->vp->name,
+		   (sample->rtt / 1000) + 1);
+
+	  slist_empty_cb(rtr_samples, (slist_free_t)sc_sample_free);
+	}
+    }
+  else
+    {
+      if((dst_list = slist_alloc()) == NULL || do_dsts_read() != 0)
+	goto done;
+
+      for(sn=slist_head_node(dst_list); sn != NULL; sn=slist_node_next(sn))
+	{
+	  dst = slist_node_item(sn);
+	  if((samples = do_read_dst_samples(dst)) == NULL ||
+	     do_process_2_prune(pruned, samples) != 0)
+	    goto done;
+
+	  scamper_addr_tostr(dst->addr, buf, sizeof(buf));
+	  while((sample = slist_head_pop(pruned)) != NULL)
+	    printf("%s %s %s %d\n", buf, sample->vp->name,
+		   method_str(sample->method), (sample->rtt / 1000) + 1);
+
+	  slist_free_cb(samples, (slist_free_t)sc_sample_free);
+	  samples = NULL;
+	}
+    }
+
+  rc = 0;
+
+ done:
+  if(pruned != NULL) slist_free(pruned);
+  if(samples != NULL) slist_free_cb(samples, (slist_free_t)sc_sample_free);
+  if(rtr_samples != NULL)
+    slist_free_cb(rtr_samples, (slist_free_t)sc_sample_free);
+  if(rtr_list != NULL)
+    slist_free_cb(rtr_list, (slist_free_t)sc_router_free);
+  return rc;
+}
+
+static void cleanup(void)
+{
+  if(dst_tree != NULL)
+    {
+      splaytree_free(dst_tree, (splaytree_free_t)sc_dst_free);
+      dst_tree = NULL;
+    }
+
+  if(dst_list != NULL)
+    {
+      slist_free_cb(dst_list, (slist_free_t)sc_dst_free);
+      dst_list = NULL;
+    }
+
+  if(vp_tree != NULL)
+    {
+      splaytree_free(vp_tree, (splaytree_free_t)sc_vp_free);
+      vp_tree = NULL;
+    }
+
+  if(vp_array != NULL)
+    {
+      free(vp_array);
+      vp_array = NULL;
+    }
+
+#ifdef HAVE_PTHREAD
+  if(db_mutex_o != 0)
+    {
+      pthread_mutex_destroy(&db_mutex);
+      db_mutex_o = 0;
+    }
+
+  if(data_mutex_o != 0)
+    {
+      pthread_mutex_destroy(&data_mutex);
+      data_mutex_o = 0;
+    }
+#endif
+
+  if(vp_pcre != NULL)
+    {
+#ifdef HAVE_PCRE2
+      pcre2_code_free(vp_pcre);
+#else
+      pcre_free(vp_pcre);
+#endif
+      vp_pcre = NULL;
+    }
+
+  do_stmt_final();
+
+  if(blob != NULL)
+    {
+      sqlite3_blob_close(blob);
+      blob = NULL;
+    }
+
+  if(db != NULL)
+    {
+      sqlite3_close(db);
+      db = NULL;
+    }
+
+  return;
+}
+
+int main(int argc, char *argv[])
+{
+#if defined(DMALLOC)
+  free(malloc(1));
+#endif
+
+  atexit(cleanup);
+
+  if(check_options(argc, argv) != 0)
+    return -1;
+
+  if(do_sqlite_open() != 0)
+    return -1;
+
+  if(options & OPT_CREATE)
+    return do_create();
+
+#ifdef HAVE_PTHREAD
+  if(pthread_mutex_init(&db_mutex, NULL) != 0)
+    return -1;
+  db_mutex_o = 1;
+#endif
+
+  if(options & OPT_IMPORT)
+    return do_import();
+  if(options & OPT_PROCESS)
+    {
+      switch(proc_x)
+	{
+	case 1: return do_process_1(); /* look for conflicting RTTs */
+	case 2: return do_process_2(); /* dump RTT constraints */
+	}
+    }
+
+  return 0;
+}

--- a/utils/sc_pinger/sc_pinger.c
+++ b/utils/sc_pinger/sc_pinger.c
@@ -2,7 +2,7 @@
  * sc_pinger : scamper driver to probe destinations with various ping
  *             methods
  *
- * $Id: sc_pinger.c,v 1.29 2023/10/20 07:28:37 mjl Exp $
+ * $Id: sc_pinger.c,v 1.30 2024/04/26 06:52:24 mjl Exp $
  *
  * Copyright (C) 2020      The University of Waikato
  * Copyright (C) 2022-2023 Matthew Luckie
@@ -159,7 +159,7 @@ static int check_printf(const char *name)
 
   for(ptr=name; *ptr != '\0'; ptr++)
     {
-      if(isprint(*ptr) == 0)
+      if(isprint((unsigned char)*ptr) == 0)
 	return 0;
       if(*ptr == '%')
 	break;
@@ -172,10 +172,10 @@ static int check_printf(const char *name)
   ptr++;
 
   /* check for valid zero padding specification, if %u is zero padded */
-  if(*ptr == '0' && isdigit(ptr[1]) != 0 && ptr[1] != '0')
+  if(*ptr == '0' && ptr[1] != '0' && isdigit((unsigned char)ptr[1]) != 0)
     {
       ptr++;
-      while(isdigit(*ptr) != 0)
+      while(isdigit((unsigned char )*ptr) != 0)
 	ptr++;
     }
 
@@ -187,7 +187,7 @@ static int check_printf(const char *name)
   /* ensure no other % */
   while(*ptr != '\0')
     {
-      if(isprint(*ptr) == 0)
+      if(isprint((unsigned char)*ptr) == 0)
 	return 0;
       if(*ptr == '%')
 	return 0;

--- a/utils/sc_prefixprober/sc_prefixprober.c
+++ b/utils/sc_prefixprober/sc_prefixprober.c
@@ -2,7 +2,7 @@
  * sc_prefixprober : scamper driver to probe addresses in specified
  *                   prefixes
  *
- * $Id: sc_prefixprober.c,v 1.36 2024/01/05 04:48:53 mjl Exp $
+ * $Id: sc_prefixprober.c,v 1.38 2024/04/26 06:52:24 mjl Exp $
  *
  * Copyright (C) 2023 The Regents of the University of California
  * Author: Matthew Luckie
@@ -212,7 +212,7 @@ static int check_printf(const char *name)
 
   for(ptr=name; *ptr != '\0'; ptr++)
     {
-      if(isprint(*ptr) == 0)
+      if(isprint((unsigned char)*ptr) == 0)
 	return 0;
       if(*ptr == '%')
 	break;
@@ -225,10 +225,10 @@ static int check_printf(const char *name)
   ptr++;
 
   /* check for valid zero padding specification, if %u is zero padded */
-  if(*ptr == '0' && isdigit(ptr[1]) != 0 && ptr[1] != '0')
+  if(*ptr == '0' && ptr[1] != '0' && isdigit((unsigned char)ptr[1]) != 0)
     {
       ptr++;
-      while(isdigit(*ptr) != 0)
+      while(isdigit((unsigned char)*ptr) != 0)
 	ptr++;
     }
 
@@ -240,7 +240,7 @@ static int check_printf(const char *name)
   /* ensure no other % */
   while(*ptr != '\0')
     {
-      if(isprint(*ptr) == 0)
+      if(isprint((unsigned char)*ptr) == 0)
 	return 0;
       if(*ptr == '%')
 	return 0;
@@ -898,7 +898,7 @@ static int dnpfile_line(char *str, void *param)
 /*
  * rec_target_4_addrs
  *
- * 
+ *
  */
 static int rec_target_4_addrs(sc_prefix_t *p,
 			      const struct in_addr *x, const struct in_addr *y)
@@ -1530,7 +1530,7 @@ static void ctrlcb(scamper_inst_t *inst, uint8_t type, scamper_task_t *task,
   else if(type == SCAMPER_CTRL_TYPE_FATAL)
     {
       print("fatal: %s", scamper_ctrl_strerror(scamper_ctrl));
-      goto err;	    
+      goto err;
     }
   return;
 
@@ -1554,7 +1554,7 @@ static int do_scamperconnect(void)
       print("%s: could not alloc scamper_ctrl", __func__);
       return -1;
     }
-  
+
   if(scamper_port != 0)
     {
       type = "port";

--- a/utils/sc_radargun/sc_radargun.c
+++ b/utils/sc_radargun/sc_radargun.c
@@ -1,7 +1,7 @@
 /*
  * sc_radargun : scamper driver to do radargun-style probing.
  *
- * $Id: sc_radargun.c,v 1.21 2024/01/16 06:55:18 mjl Exp $
+ * $Id: sc_radargun.c,v 1.23 2024/04/26 06:52:24 mjl Exp $
  *
  * Copyright (C) 2014      The Regents of the University of California
  * Copyright (C) 2016      The University of Waikato
@@ -1476,7 +1476,7 @@ static int addrfile_line(char *line, void *param)
       start = ptr = line;
       while(last == 0)
 	{
-	  if(*ptr == '\0' || isspace(*ptr) != 0)
+	  if(*ptr == '\0' || isspace((unsigned char)*ptr) != 0)
 	    {
 	      if(*ptr == '\0')
 		last = 1;
@@ -1488,7 +1488,7 @@ static int addrfile_line(char *line, void *param)
 	      if(last == 0)
 		{
 		  ptr++;
-		  while(*ptr != '\0' && isspace(*ptr) != 0)
+		  while(*ptr != '\0' && isspace((unsigned char)*ptr) != 0)
 		    ptr++;
 		  if(*ptr == '\0')
 		    last = 1;
@@ -1918,7 +1918,7 @@ static int process_dealias_1(scamper_dealias_t *dealias)
 	  slist_qsort(addrset->addrs, (slist_cmp_t)sc_addr2set_cmp);
 	}
       dlist_qsort(list, (dlist_cmp_t)sc_addrset_cmp);
-      
+
       while((addrset = dlist_head_pop(list)) != NULL)
 	{
 	  i = 0;

--- a/utils/sc_remoted/sc_remoted.c
+++ b/utils/sc_remoted/sc_remoted.c
@@ -1,12 +1,12 @@
 /*
  * sc_remoted
  *
- * $Id: sc_remoted.c,v 1.106 2024/01/03 00:39:00 mjl Exp $
+ * $Id: sc_remoted.c,v 1.115 2024/06/26 22:08:27 mjl Exp $
  *
  *        Matthew Luckie
  *        mjl@luckie.org.nz
  *
- * Copyright (C) 2014-2023 Matthew Luckie
+ * Copyright (C) 2014-2024 Matthew Luckie
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -139,7 +139,7 @@
  * scamper can resume by sending a resumption message with the same
  * magic value scamper supplied initially.  the resume message also
  * includes the next sequence number the scamper expects from remoted,
- * the left edge of the 
+ * the left edge of the
  *
  * uint8_t   magic_len
  * uint8_t  *magic
@@ -235,15 +235,15 @@ typedef struct sc_fd
 typedef struct sc_master
 {
   sc_unit_t          *unit;
-  char               *monitorname;
-  char               *name;
-  uint8_t            *magic;
-  uint8_t             magic_len;
-  int                 mode;
+  char               *monitorname; /* -M parameter to scamper */
+  char               *name;        /* socket name (prefaced by monitorname) */
+  uint8_t            *magic;       /* magic value first sent by scamper */
+  uint8_t             magic_len;   /* size of magic first sent by scamper */
+  int                 mode;        /* connect / go / flush */
 
-  sc_fd_t            *unix_fd;
-  sc_fd_t             inet_fd;
-  scamper_writebuf_t *inet_wb;
+  sc_fd_t            *unix_fd;     /* socket that accepts clients */
+  sc_fd_t             inet_fd;     /* the socket to the scamper instance */
+  scamper_writebuf_t *inet_wb;     /* data outstanding towards scamper */
 
 #ifdef HAVE_OPENSSL
   int                 inet_mode;
@@ -277,14 +277,14 @@ typedef struct sc_master
  */
 typedef struct sc_channel
 {
-  uint32_t            id;
+  uint32_t            id;      /* id, derived from master->next_channel */
   sc_unit_t          *unit;
   sc_fd_t            *unix_fd;
   scamper_linepoll_t *unix_lp;
   scamper_writebuf_t *unix_wb;
-  sc_master_t        *master;
-  dlist_node_t       *node;
-  uint8_t             flags;
+  sc_master_t        *master;  /* corresponding master */
+  dlist_node_t       *node;    /* node in master->channels */
+  uint8_t             flags;   /* channel flags: eof tx/rx */
 } sc_channel_t;
 
 /*
@@ -509,7 +509,7 @@ static int check_options(int argc, char *argv[])
 	      return -1;
 	    }
 	  break;
-	  
+
 	case 'P':
 	  opt_addrport = optarg;
 	  break;
@@ -649,18 +649,18 @@ static void remote_debug(const char *func, const char *format, ...)
   return;
 }
 
-static int sc_fd_peername(const sc_fd_t *fd, char *buf, size_t len)
+static int fd_peername(int fd, char *buf, size_t len, int with_port)
 {
   struct sockaddr_storage sas;
-  socklen_t sl;
+  socklen_t socklen;
 
-  sl = sizeof(sas);
-  if(getpeername(fd->fd, (struct sockaddr *)&sas, &sl) != 0)
+  socklen = sizeof(sas);
+  if(getpeername(fd, (struct sockaddr *)&sas, &socklen) != 0)
     {
       remote_debug(__func__, "could not getpeername: %s", strerror(errno));
       return -1;
     }
-  if(sockaddr_tostr((struct sockaddr *)&sas, buf, len) == NULL)
+  if(sockaddr_tostr((struct sockaddr *)&sas, buf, len, with_port) == NULL)
     {
       remote_debug(__func__, "could not convert to string");
       return -1;
@@ -1130,46 +1130,12 @@ static int sc_master_is_valid_client_cert_1(sc_master_t *ms)
 }
 #endif /* HAVE_OPENSSL */
 
-/*
- * sc_master_unix_create
- *
- * create a unix domain socket for the scamper instance, that local
- * users can connect to in order to interact with the remote scamper
- * instance.  The name of the socket is derived from getpeername on the
- * Internet socket, and the monitorname if the remote scamper supplied
- * that variable.
- */
-static int sc_master_unix_create(sc_master_t *ms)
+static int unix_create(const char *filename)
 {
+  int fd = -1;
   struct sockaddr_un sn;
   mode_t mode;
-  char sab[128], filename[65535], tmp[512];
-  int fd;
-
-  /*
-   * these are set so that we know whether or not to take
-   * responsibility for cleaning them up upon a failure condition.
-   */
-  fd = -1;
-  filename[0] = '\0';
-
-  /* figure out the name for the unix domain socket */
-  if(sc_fd_peername(&ms->inet_fd, sab, sizeof(sab)) != 0)
-    goto err;
-  if(ms->monitorname != NULL)
-    {
-      snprintf(tmp, sizeof(tmp), "%s-%s", ms->monitorname, sab);
-      ms->name = strdup(tmp);
-    }
-  else
-    {
-      ms->name = strdup(sab);
-    }
-  if(ms->name == NULL)
-    {
-      remote_debug(__func__, "could not strdup ms->name: %s", strerror(errno));
-      goto err;
-    }
+  int bound = 0;
 
   /* create a unix domain socket for the remote scamper process */
   if((fd = socket(AF_UNIX, SOCK_STREAM, 0)) == -1)
@@ -1178,19 +1144,17 @@ static int sc_master_unix_create(sc_master_t *ms)
 		   strerror(errno));
       goto err;
     }
-  snprintf(filename, sizeof(filename), "%s/%s", unix_name, ms->name);
   if(sockaddr_compose_un((struct sockaddr *)&sn, filename) != 0)
     {
-      filename[0] = '\0'; /* could not actually bind so no unlink */
       remote_debug(__func__, "could not compose socket: %s", strerror(errno));
       goto err;
     }
   if(bind(fd, (struct sockaddr *)&sn, sizeof(sn)) != 0)
     {
-      filename[0] = '\0'; /* could not actually bind so no unlink */
       remote_debug(__func__, "could not bind unix socket: %s",strerror(errno));
       goto err;
     }
+  bound = 1;
 
   /* set the requested permissions on the control sockets */
   mode = S_IRWXU;
@@ -1207,6 +1171,57 @@ static int sc_master_unix_create(sc_master_t *ms)
       remote_debug(__func__, "could not listen: %s", strerror(errno));
       goto err;
     }
+
+  return fd;
+
+ err:
+  if(bound != 0) unlink(filename);
+  if(fd != -1) close(fd);
+  return -1;
+}
+
+/*
+ * sc_master_unix_create
+ *
+ * create a unix domain socket for the scamper instance, that local
+ * users can connect to in order to interact with the remote scamper
+ * instance.  The name of the socket is derived from getpeername on the
+ * Internet socket, and the monitorname if the remote scamper supplied
+ * that variable.
+ */
+static int sc_master_unix_create(sc_master_t *ms)
+{
+  char sab[128], filename[65535], tmp[512];
+  int fd;
+
+  /*
+   * these are set so that we know whether or not to take
+   * responsibility for cleaning them up upon a failure condition.
+   */
+  fd = -1;
+  filename[0] = '\0';
+
+  /* figure out the name for the unix domain socket */
+  if(fd_peername(ms->inet_fd.fd, sab, sizeof(sab), 1) != 0)
+    goto err;
+  if(ms->monitorname != NULL)
+    {
+      snprintf(tmp, sizeof(tmp), "%s-%s", ms->monitorname, sab);
+      ms->name = strdup(tmp);
+    }
+  else
+    {
+      ms->name = strdup(sab);
+    }
+  if(ms->name == NULL)
+    {
+      remote_debug(__func__, "could not strdup ms->name: %s", strerror(errno));
+      goto err;
+    }
+
+  snprintf(filename, sizeof(filename), "%s/%s", unix_name, ms->name);
+  if((fd = unix_create(filename)) == -1)
+    goto err;
 
   /*
    * at this point, allocate the unix_fd structure and take
@@ -1228,8 +1243,11 @@ static int sc_master_unix_create(sc_master_t *ms)
   return 0;
 
  err:
-  if(fd != -1) close(fd);
-  if(filename[0] != '\0') unlink(filename);
+  if(fd != -1)
+    {
+      if(filename[0] != '\0') unlink(filename);
+      close(fd);
+    }
   return -1;
 }
 
@@ -1381,8 +1399,8 @@ static int sc_master_control_master(sc_master_t *ms, uint8_t *buf, size_t len)
       monitorname = (char *)(buf+off);
       for(u8=0; u8<monitorname_len-1; u8++)
 	{
-	  if(isalnum(monitorname[u8]) == 0 &&
-	     monitorname[u8] != '.' && monitorname[u8] != '-')
+	  if(monitorname[u8] != '.' && monitorname[u8] != '-' &&
+	     isalnum((unsigned char)monitorname[u8]) == 0)
 	    goto err;
 	}
       if(monitorname[monitorname_len-1] != '\0')
@@ -1417,7 +1435,7 @@ static int sc_master_control_master(sc_master_t *ms, uint8_t *buf, size_t len)
     goto err;
 
   /* send the list name to the client. do not expect an ack */
-  if(sc_fd_peername(&ms->inet_fd, sab, sizeof(sab)) != 0)
+  if(fd_peername(ms->inet_fd.fd, sab, sizeof(sab), 1) != 0)
     goto err;
   remote_debug(__func__, "%s", sab);
   ms->mode = MASTER_MODE_GO;
@@ -1670,6 +1688,11 @@ static int sc_master_control_resume(sc_master_t *ms, uint8_t *buf, size_t len)
   return -1;
 }
 
+/*
+ * sc_master_control
+ *
+ * process data received on the inet_fd and placed in the buf struct.
+ */
 static int sc_master_control(sc_master_t *ms)
 {
   uint32_t seq;
@@ -1818,13 +1841,13 @@ static void sc_master_inet_read_cb(sc_master_t *ms, uint8_t *buf, size_t len)
       if(channel->unix_wb != NULL)
 	{
 	  if(scamper_writebuf_send(channel->unix_wb, ptr, msglen) != 0)
-	    sc_unit_gc(channel->unit);	
+	    sc_unit_gc(channel->unit);
 	  sc_fd_write_add(channel->unix_fd);
 	}
     }
 
   return;
-  
+
  err:
   sc_unit_gc(ms->unit);
   return;
@@ -1947,13 +1970,11 @@ static void sc_master_inet_read_do(sc_master_t *ms)
  */
 static void sc_master_unix_accept_do(sc_master_t *ms)
 {
-  struct sockaddr_storage ss;
-  socklen_t socklen = sizeof(ss);
   sc_channel_t *cn = NULL;
   uint8_t msg[1+4];
   int s = -1;
 
-  if((s = accept(ms->unix_fd->fd, (struct sockaddr *)&ss, &socklen)) == -1)
+  if((s = accept(ms->unix_fd->fd, NULL, NULL)) == -1)
     {
       remote_debug(__func__, "accept failed: %s", strerror(errno));
       goto err;
@@ -2033,7 +2054,7 @@ static void sc_master_free(sc_master_t *ms)
 static sc_master_t *sc_master_alloc(int fd)
 {
   sc_master_t *ms = NULL;
-  
+
 #ifdef HAVE_OPENSSL
   int rc;
 #endif
@@ -2238,14 +2259,11 @@ static void sc_channel_free(sc_channel_t *cn)
  */
 static int serversocket_accept(int ss)
 {
-  struct sockaddr_storage sas;
   sc_master_t *ms = NULL;
-  socklen_t slen;
   int inet_fd = -1;
   char buf[256];
 
-  slen = sizeof(ss);
-  if((inet_fd = accept(ss, (struct sockaddr *)&sas, &slen)) == -1)
+  if((inet_fd = accept(ss, NULL, NULL)) == -1)
     {
       remote_debug(__func__, "could not accept: %s", strerror(errno));
       goto err;
@@ -2261,7 +2279,7 @@ static int serversocket_accept(int ss)
   if(ms == NULL)
     goto err;
 
-  if(sc_fd_peername(&ms->inet_fd, buf, sizeof(buf)) == 0)
+  if(fd_peername(ms->inet_fd.fd, buf, sizeof(buf), 1) == 0)
     remote_debug(__func__, "%s", buf);
 
   if(sc_fd_read_add(&ms->inet_fd) != 0)
@@ -2290,7 +2308,7 @@ static int serversocket_accept(int ss)
 static int serversocket_init_sa(const struct sockaddr *sa)
 {
   char buf[256];
-  int opt, fd = -1;
+  int fd = -1;
 
   if((fd = socket(sa->sa_family, SOCK_STREAM, IPPROTO_TCP)) < 0)
     {
@@ -2299,8 +2317,7 @@ static int serversocket_init_sa(const struct sockaddr *sa)
       goto err;
     }
 
-  opt = 1;
-  if(setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (void *)&opt, sizeof(opt)) != 0)
+  if(setsockopt_int(fd, SOL_SOCKET, SO_REUSEADDR, 1) != 0)
     {
       remote_debug(__func__, "could not set SO_REUSEADDR on %s socket: %s",
 		   sa->sa_family == AF_INET ? "ipv4" : "ipv6", strerror(errno));
@@ -2310,9 +2327,7 @@ static int serversocket_init_sa(const struct sockaddr *sa)
 #ifdef IPV6_V6ONLY
   if(sa->sa_family == PF_INET6)
     {
-      opt = 1;
-      if(setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY,
-		    (void *)&opt, sizeof(opt)) != 0)
+      if(setsockopt_int(fd, IPPROTO_IPV6, IPV6_V6ONLY, 1) != 0)
 	{
 	  remote_debug(__func__, "could not set IPV6_V6ONLY: %s",
 		       strerror(errno));
@@ -2325,7 +2340,7 @@ static int serversocket_init_sa(const struct sockaddr *sa)
     {
       remote_debug(__func__, "could not bind %s socket to %s: %s",
 		   sa->sa_family == AF_INET ? "ipv4" : "ipv6",
-		   sockaddr_tostr(sa, buf, sizeof(buf)), strerror(errno));
+		   sockaddr_tostr(sa, buf, sizeof(buf), 1), strerror(errno));
       goto err;
     }
 

--- a/utils/sc_tbitblind/sc_tbitblind.c
+++ b/utils/sc_tbitblind/sc_tbitblind.c
@@ -146,7 +146,7 @@ static int check_options(int argc, char *argv[])
 	  options |= OPT_APPTYPE;
 	  opt_apptype = optarg;
 	  break;
-	  
+
 	case 'c':
 	  options |= OPT_COMPLETED;
 	  opt_comp = optarg;
@@ -272,7 +272,7 @@ static int check_options(int argc, char *argv[])
 	}
       wait_between = lo;
     }
-  
+
   if(opt_text != NULL)
     {
       if((text = fopen(opt_text, "w")) == NULL)
@@ -404,7 +404,7 @@ static void target_free(target_t *target)
 
   if(target->methods != NULL)
     slist_free(target->methods);
-  
+
   free(target);
   return;
 }
@@ -809,10 +809,10 @@ static int process_tbit(target_t *target, scamper_tbit_t *tbit)
     {
       target->mode++;
     }
-  
+
   if(target->mode > MODE_LAST)
     goto completed;
-  
+
   /* wait before we try again, by default a minute */
   timeval_add_s(&target->next, &now, wait_between);
   if((target->hn = heap_insert(heap, target)) == NULL)

--- a/utils/sc_tbitpmtud/sc_tbitpmtud.c
+++ b/utils/sc_tbitpmtud/sc_tbitpmtud.c
@@ -21,7 +21,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
- * $Id: sc_tbitpmtud.c,v 1.35 2023/09/24 22:35:02 mjl Exp $
+ * $Id: sc_tbitpmtud.c,v 1.37 2024/04/26 06:52:24 mjl Exp $
  */
 
 #ifdef HAVE_CONFIG_H
@@ -392,7 +392,7 @@ static int check_options(int argc, char *argv[])
 	  usage(OPT_IP2AS);
 	  return -1;
 	}
-      
+
       return 0;
     }
 
@@ -1405,23 +1405,23 @@ static int ip2as_line(char *line, void *param)
   n = line;
 
   m = line;
-  while(isspace(*m) == 0 && *m != '\0')
+  while(*m != '\0' && isspace((unsigned char)*m) == 0)
     m++;
   if(*m == '\0')
     return -1;
   *m = '\0'; m++;
-  while(isspace(*m) != 0)
+  while(isspace((unsigned char)*m) != 0)
     m++;
   if(string_tolong(m, &lo) != 0)
     return -1;
 
   a = m;
-  while(isspace(*a) == 0 && *a != '\0')
+  while(*a != '\0' && isspace((unsigned char)*a) == 0)
     a++;
   if(*a == '\0')
     return -1;
   *a = '\0'; a++;
-  while(isspace(*a) != 0)
+  while(isspace((unsigned char)*a) != 0)
     a++;
 
   if(inet_pton(AF_INET, n, &in) == 1)
@@ -1544,7 +1544,7 @@ static char *percentage(char *buf, size_t len, uint32_t a, uint32_t x)
   if(x == 0) string_concat(buf, len, &off, "-");
   else if(a == x) string_concat(buf, len, &off, "100%%");
   else string_concat(buf, len, &off, "%.1f%%", (float)(a * 100) / x);
-  return buf;    
+  return buf;
 }
 
 typedef struct sc_mssresult
@@ -1865,7 +1865,7 @@ static int finish_2(void)
 	  artree = tree_2_6;
 	  tasr = total_2_6;
 	}
-      
+
       splaytree_inorder(artree, tree_to_slist, arlist);
       if(slist_count(arlist) == 0)
 	continue;

--- a/utils/sc_uptime/sc_uptime.c
+++ b/utils/sc_uptime/sc_uptime.c
@@ -9,7 +9,7 @@
  * Copyright (C) 2023 Matthew Luckie
  * Copyright (C) 2023 The Regents of the University of California
  *
- * $Id: sc_uptime.c,v 1.88 2023/09/24 22:35:02 mjl Exp $
+ * $Id: sc_uptime.c,v 1.89 2024/03/04 19:36:41 mjl Exp $
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -2021,7 +2021,7 @@ static int up_import_blob_new(sc_dst_t *dst, sqlite3_stmt *st_sample_ins,
 {
   int x;
 
-  /* insert an empty blob into the database */     
+  /* insert an empty blob into the database */
   sqlite3_bind_int64(st_sample_ins, 1, dst->id);
   if((x = sqlite3_step(st_sample_ins)) != SQLITE_DONE)
     {
@@ -2272,7 +2272,7 @@ static int up_import(void)
 		  fprintf(stderr, "%s: could not insert address %s: %s\n",
 			  __func__, buf, sqlite3_errstr(x));
 		  goto done;
-		}	      
+		}
 	      dst->id = sqlite3_last_insert_rowid(db);
 	      sqlite3_clear_bindings(st_addr_ins);
 	      sqlite3_reset(st_addr_ins);
@@ -2480,7 +2480,7 @@ static int up_reboots_init(slist_t *sample_list, sc_sample_t ***out, int *outc)
 
   *out = samples;
   *outc = samplec;
-  return 0;  
+  return 0;
 }
 
 static void sc_ipidseq_free(sc_ipidseq_t *seq)
@@ -2536,7 +2536,7 @@ static int up_reboots_seqs_make(slist_t *seqs, sc_sample_t **samples,
 
  err:
   if(seq != NULL) sc_ipidseq_free(seq);
-  return -1;      
+  return -1;
 }
 
 static int up_reboots_seqs_class_reseed(slist_t *seqs)
@@ -2861,7 +2861,7 @@ static int up_reboots_doone(sc_dst_t *dst, slist_t *samplist, slist_t *reboots)
       /* if a sequence ended here, then no reboot */
       if(seq->prev != NULL)
 	goto next;
-      
+
       /*
        * both the current and previous sequences must be assigned from
        * a counter to infer a reboot

--- a/utils/sc_warts2json/sc_warts2json.c
+++ b/utils/sc_warts2json/sc_warts2json.c
@@ -1,7 +1,7 @@
 /*
  * sc_warts2json
  *
- * $Id: sc_warts2json.c,v 1.11 2023/05/03 20:50:01 mjl Exp $
+ * $Id: sc_warts2json.c,v 1.12 2024/03/21 22:44:03 mjl Exp $
  *
  *        Matthew Luckie
  *        mjl@luckie.org.nz
@@ -40,6 +40,7 @@
 #include "dealias/scamper_dealias.h"
 #include "tbit/scamper_tbit.h"
 #include "host/scamper_host.h"
+#include "udpprobe/scamper_udpprobe.h"
 #include "utils.h"
 
 int main(int argc, char *argv[])
@@ -53,6 +54,7 @@ int main(int argc, char *argv[])
     SCAMPER_FILE_OBJ_DEALIAS,
     SCAMPER_FILE_OBJ_TBIT,
     SCAMPER_FILE_OBJ_HOST,
+    SCAMPER_FILE_OBJ_UDPPROBE,
   };
   scamper_file_t *in, *out;
   scamper_file_filter_t *filter;
@@ -120,6 +122,8 @@ int main(int argc, char *argv[])
 	    scamper_tracelb_free(data);
 	  else if(type == SCAMPER_FILE_OBJ_HOST)
 	    scamper_host_free(data);
+	  else if(type == SCAMPER_FILE_OBJ_UDPPROBE)
+	    scamper_udpprobe_free(data);
 	  else if(type == SCAMPER_FILE_OBJ_CYCLE_START ||
 		  type == SCAMPER_FILE_OBJ_CYCLE_STOP)
 	    scamper_cycle_free(data);

--- a/utils/sc_wartscat/sc_wartscat.c
+++ b/utils/sc_wartscat/sc_wartscat.c
@@ -3,7 +3,7 @@
  *
  * This is a utility program to concatenate warts data files together.
  *
- * $Id: sc_wartscat.c,v 1.47 2024/01/02 20:24:52 mjl Exp $
+ * $Id: sc_wartscat.c,v 1.48 2024/03/04 01:52:23 mjl Exp $
  *
  * Copyright (C) 2007-2011 The University of Waikato
  * Copyright (C) 2022-2023 Matthew Luckie
@@ -379,7 +379,7 @@ static int simple_cat(void)
       if(rc != 0)
 	{
 	  fprintf(stderr, "%s: error reading %s\n", __func__,
-		  scamper_file_getfilename(infiles[1]));
+		  scamper_file_getfilename(infiles[i]));
 	  return -1;
 	}
 

--- a/utils/sc_wartsfix/sc_wartsfix.c
+++ b/utils/sc_wartsfix/sc_wartsfix.c
@@ -1,7 +1,7 @@
 /*
  * warts-fix
  *
- * $Id: sc_wartsfix.c,v 1.13 2023/08/11 08:59:41 mjl Exp $
+ * $Id: sc_wartsfix.c,v 1.14 2024/04/26 06:50:53 mjl Exp $
  *
  *        Matthew Luckie
  *        mjl@luckie.org.nz
@@ -114,7 +114,7 @@ int main(int argc, char *argv[])
 
 	  memcpy(tmp, hdr, 8);
 	  rc = read(in, tmp+8, u32);
-	  if(rc != u32)
+	  if(rc < 0 || (uint32_t)rc != u32)
 	    break;
 	}
       else


### PR DESCRIPTION
update scamper to 20240716 via merges from master branch, which merged from upstream release.  this also includes a patch to 20240716 that, for trace when -N squeries is used, processes datalink timestamps for transmitted packets where scamper has already recorded a reply.  this is most likely to happen for the first few hops, and is most likely to occur with -O ring (the default) as the ring buffer is likely to present the transmitted packet after scamper has already received the responses for the first few hops.