### PR TITLE
enforce a 5 second gap for port reuse

### DIFF
--- a/scamper/scamper.c
+++ b/scamper/scamper.c
@@ -2205,6 +2205,7 @@ static int scamper(int argc, char *argv[])
 
       if(scamper_queue_event_proc(&tv) != 0)
 	goto done;
+      scamper_task_sig_expiry_run(&tv);
 
       /* take any 'done' tasks and output them now */
       while((task = scamper_queue_getdone(&tv)) != NULL)

--- a/scamper/scamper_task.h
+++ b/scamper/scamper_task.h
@@ -1,7 +1,7 @@
 /*
  * scamper_task.h
  *
- * $Id: scamper_task.h,v 1.52 2024/02/27 01:01:44 mjl Exp $
+ * $Id: scamper_task.h,v 1.53 2024/08/28 01:05:53 mjl Exp $
  *
  * Copyright (C) 2005-2006 Matthew Luckie
  * Copyright (C) 2006-2011 The University of Waikato
@@ -214,7 +214,7 @@ void scamper_task_sig_free(scamper_task_sig_t *sig);
 int scamper_task_sig_add(scamper_task_t *task, scamper_task_sig_t *sig);
 scamper_task_t *scamper_task_sig_block(scamper_task_t *task);
 int scamper_task_sig_install(scamper_task_t *task);
-void scamper_task_sig_deinstall(scamper_task_t *task);
+void scamper_task_sig_expiry_run(const struct timeval *now);
 scamper_task_t *scamper_task_find(scamper_task_sig_t *sig);
 char *scamper_task_sig_tostr(scamper_task_sig_t *sig, char *buf, size_t len);
 int scamper_task_sig_sport_used(struct scamper_addr *dst, uint8_t proto,


### PR DESCRIPTION
enforce a 5 second gap before allowing a task with an overlapping signature to reuse a socket, with trace -s 0 and ping -F 0