### PR TITLE
Fix build for Darwin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,9 +57,14 @@ jobs:
 
   build-macos:
     name: Build (macos)
-    runs-on: macos-latest
-    env:
-      platform: darwin-amd64
+    strategy:
+      matrix:
+        include:
+          - runner: macos-latest
+            platform: darwin-arm64
+          - runner: macos-13
+            platform: darwin-amd64
+    runs-on: ${{ matrix.runner }}
     steps:
       # SETUP
       - name: Checkout code
@@ -79,15 +84,15 @@ jobs:
           autoreconf -vfi
           ./configure --disable-libs --disable-utils --with-openssl=disabled
           make
-          mkdir -p ./build/${{env.platform}}
-          cp scamper/scamper ./build/${{env.platform}}
+          mkdir -p ./build/${{matrix.platform}}
+          cp scamper/scamper ./build/${{matrix.platform}}
           echo "Successfully built scamper version: $(./scamper/scamper -v)"
 
       # STORE BINARIES
       - name: Archive compiled binaries
         uses: actions/upload-artifact@v4
         with:
-          name: scamper-build-${{ env.platform }}
+          name: scamper-build-${{ matrix.platform }}
           path: build/**/scamper
 
   docs:

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ lib/python/scamper.c
 
 # Local build artifacts
 build/
+.idea/


### PR DESCRIPTION
Low priority, but noticed that darwin-amd64 is now actually arm64 since macos-latest changed, so here's a PR for fixing it (and adding real amd64 version). 

NOTE: I haven't run this as I'm not sure what all the different branch structures are in this repo or if this should be in master or no or what the propagation strategy is for branches in this repo, so this is really just the easy part of it, which is the action update. Feel free to kill this if it's in the wrong place or branch.