### PR TITLE
Fix build for darwin arch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,9 +57,14 @@ jobs:
 
   build-macos:
     name: Build (macos)
-    runs-on: macos-latest
-    env:
-      platform: darwin-amd64
+    strategy:
+      matrix:
+        include:
+          - runner: macos-latest
+            platform: darwin-arm64
+          - runner: macos-13
+            platform: darwin-amd64
+    runs-on: ${{ matrix.runner }}
     steps:
       # SETUP
       - name: Checkout code
@@ -79,15 +84,15 @@ jobs:
           autoreconf -vfi
           ./configure --disable-libs --disable-utils
           make
-          mkdir -p ./build/${{env.platform}}
-          cp scamper/scamper ./build/${{env.platform}}
+          mkdir -p ./build/${{matrix.platform}}
+          cp scamper/scamper ./build/${{matrix.platform}}
           echo "Successfully built scamper version: $(./scamper/scamper -v)"
 
       # STORE BINARIES
       - name: Archive compiled binaries
         uses: actions/upload-artifact@v4
         with:
-          name: scamper-build-${{ env.platform }}
+          name: scamper-build-${{ matrix.platform }}
           path: build/**/scamper
 
   docs:

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ lib/python/scamper.c
 
 # Local build artifacts
 build/
+.idea/


### PR DESCRIPTION
Closed previous PR against a6r and created this against master.

Now creates artifacts for both darwin amd64 and arm64. Previous amd64-labeled artifact was actual arm64, switched when github runner `macos-latest` label changed.